### PR TITLE
Lambda / CLI tool for refreshing Trusted Advisor

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,16 @@
 
 
 [[projects]]
+  name = "github.com/aws/aws-lambda-go"
+  packages = [
+    "lambda",
+    "lambda/messages",
+    "lambdacontext"
+  ]
+  revision = "4d30d0ff60440c2d0480a15747c96ee71c3c53d4"
+  version = "v1.2.0"
+
+[[projects]]
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -14,15 +24,22 @@
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
     "aws/credentials/stscreds",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/sdkio",
+    "internal/sdkrand",
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/ec2query",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
     "private/protocol/query",
     "private/protocol/query/queryutil",
     "private/protocol/rest",
@@ -32,16 +49,23 @@
     "service/ec2",
     "service/rds",
     "service/s3",
-    "service/sts"
+    "service/sts",
+    "service/support"
   ]
-  revision = "f62f7b7c5425f2b1a630932617477bdeac6dc371"
-  version = "v1.12.55"
+  revision = "c9af76f2478f81c6566d0f7f4d522254ec7c0b52"
+  version = "v1.14.3"
 
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "32e4c1e6bc4e7d0d8451aa6b75200d19e37a536a"
-  version = "v1.32.0"
+  revision = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5"
+  version = "v1.37.0"
+
+[[projects]]
+  name = "github.com/jessevdk/go-flags"
+  packages = ["."]
+  revision = "c6ca198ec95c841fdb89fc0de7496fed11ab854e"
+  version = "v1.4.0"
 
 [[projects]]
   name = "github.com/jmespath/go-jmespath"
@@ -53,13 +77,39 @@
   name = "github.com/jstemmer/go-junit-report"
   packages = [
     ".",
+    "formatter",
     "parser"
   ]
-  revision = "d9db44172dfb1d1ba6d68749e38ea73f64525e93"
+  revision = "d0a98937db5130acbf4231fe8bd3897fe10a7ac7"
+
+[[projects]]
+  name = "go.uber.org/atomic"
+  packages = ["."]
+  revision = "1ea20fb1cbb1cc08cbd0d913a96dead89aa18289"
+  version = "v1.3.2"
+
+[[projects]]
+  name = "go.uber.org/multierr"
+  packages = ["."]
+  revision = "3c4937480c32f4c13a875a1829af76c98ca3d40a"
+  version = "v1.1.0"
+
+[[projects]]
+  name = "go.uber.org/zap"
+  packages = [
+    ".",
+    "buffer",
+    "internal/bufferpool",
+    "internal/color",
+    "internal/exit",
+    "zapcore"
+  ]
+  revision = "eeedf312bc6c57391d84767a4cd413f02a917974"
+  version = "v1.8.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "863653d9be671cbe86dc04aca660a862ea017ae4db595876227360e90cdee469"
+  inputs-digest = "3f24acfb32648cb3902953a6c44fa906cd05a4c9f966ce76c653af0a8b3b3a7e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ go get -u github.com/trussworks/truss-aws-tools/...
 ``` shell
 brew install dep
 brew install pre-commit
-brew install gometalinter
+go get -u github.com/alecthomas/gometalinter
 gometalinter --install
 ```
 

--- a/cmd/trusted-advisor-refresh/main.go
+++ b/cmd/trusted-advisor-refresh/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/trussworks/truss-aws-tools/internal/aws/session"
+	"github.com/trussworks/truss-aws-tools/pkg/tarefresh"
+
+	"github.com/aws/aws-sdk-go/service/support"
+	flag "github.com/jessevdk/go-flags"
+	"go.uber.org/zap"
+)
+
+// Options are the command line options
+type Options struct {
+	Profile string `short:"p" long:"profile" description:"The AWS profile to use." required:"false"`
+}
+
+// makeSupportClient makes an Support client
+func makeSupportClient(region, profile string) *support.Support {
+	sess := session.MustMakeSession(region, profile)
+	supportClient := support.New(sess)
+	return supportClient
+}
+
+func main() {
+	var options Options
+
+	parser := flag.NewParser(&options, flag.Default)
+	_, err := parser.Parse()
+	if err != nil {
+		os.Exit(1)
+	}
+
+	// Trusted Advisor only works in us-east-1
+	supportClient := makeSupportClient("us-east-1", options.Profile)
+	logger, err := zap.NewProduction()
+	if err != nil {
+		log.Fatalf("can't initialize zap logger: %v", err)
+	}
+
+	tar := tarefresh.TrustedAdvisorRefresh{Logger: logger, SupportClient: supportClient}
+	err = tar.Refresh()
+	if err != nil {
+		logger.Fatal("failed to refresh trusted advisor", zap.Error(err))
+	}
+}

--- a/lambda/trusted-advisor-refresh/main.go
+++ b/lambda/trusted-advisor-refresh/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+
+	"github.com/trussworks/truss-aws-tools/internal/aws/session"
+	"github.com/trussworks/truss-aws-tools/pkg/tarefresh"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/service/support"
+	"go.uber.org/zap"
+)
+
+// makeSupportClient makes an Support client
+func makeSupportClient(region, profile string) *support.Support {
+	sess := session.MustMakeSession(region, profile)
+	supportClient := support.New(sess)
+	return supportClient
+}
+
+func triggerRefresh() {
+	// Trusted Advisor only works in us-east-1 and passing a profile is not necessary
+	supportClient := makeSupportClient("us-east-1", "")
+	logger, err := zap.NewProduction()
+	if err != nil {
+		log.Fatalf("can't initialize zap logger: %v", err)
+	}
+
+	tar := tarefresh.TrustedAdvisorRefresh{Logger: logger, SupportClient: supportClient}
+	err = tar.Refresh()
+	if err != nil {
+		logger.Fatal("failed to refresh trusted advisor", zap.Error(err))
+	}
+}
+
+func main() {
+	lambda.Start(triggerRefresh)
+}

--- a/pkg/tarefresh/refresh.go
+++ b/pkg/tarefresh/refresh.go
@@ -1,0 +1,63 @@
+package tarefresh
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/support"
+	"go.uber.org/zap"
+)
+
+// TrustedAdvisorRefresh is a AWS support session for refreshing Trusted Advisor
+type TrustedAdvisorRefresh struct {
+	Logger        *zap.Logger
+	SupportClient *support.Support
+}
+
+func isCheckRefreshable(check string) bool {
+	unrefreshableChecks := []string{
+		"AWS Direct Connect Connection Redundancy",
+		"AWS Direct Connect Location Redundancy",
+		"AWS Direct Connect Virtual Interface Redundancy",
+		"PV Driver Version for EC2 Windows Instances",
+		"EC2Config Service for EC2 Windows Instances",
+		"Amazon EBS Public Snapshots",
+		"Amazon RDS Public Snapshots",
+	}
+
+	for _, u := range unrefreshableChecks {
+		if u == check {
+			return false
+		}
+	}
+	return true
+}
+
+// Refresh iterates through all Trusted Advisor checks and triggers a refresh.
+// Unrefreshable checks will be logged as an error
+func (r *TrustedAdvisorRefresh) Refresh() error {
+	describeParams := &support.DescribeTrustedAdvisorChecksInput{
+		Language: aws.String("en"),
+	}
+	resp, err := r.SupportClient.DescribeTrustedAdvisorChecks(describeParams)
+	if err != nil {
+		return err
+	}
+
+	for _, s := range resp.Checks {
+		checkParams := &support.RefreshTrustedAdvisorCheckInput{
+			CheckId: aws.String(*s.Id), // Required
+		}
+
+		r.Logger.Info("refreshing",
+			zap.String("name", *s.Name),
+			zap.String("id", *s.Id),
+		)
+		if isCheckRefreshable(*s.Name) {
+			_, err = r.SupportClient.RefreshTrustedAdvisorCheck(checkParams)
+			if err != nil {
+				r.Logger.Error("unable to refresh", zap.Error(err))
+			}
+		}
+
+	}
+	return err
+}

--- a/pkg/tarefresh/refresh_test.go
+++ b/pkg/tarefresh/refresh_test.go
@@ -1,0 +1,17 @@
+package tarefresh
+
+import (
+	"testing"
+)
+
+func TestIsCheckRefreshable(t *testing.T) {
+	refreshable := isCheckRefreshable("I'm Refreshable")
+	if !refreshable {
+		t.Fatalf("isCheckRefreshable() is false, \n want true")
+	}
+	notRefreshable := isCheckRefreshable("AWS Direct Connect Connection Redundancy")
+	if notRefreshable {
+		t.Fatalf("isCheckRefreshable() is true, \n want false")
+	}
+
+}


### PR DESCRIPTION
Trusted Advisor can now track things like service limits in CloudWatch. This is nice because it makes setting alarms easy. The main issue is Trusted Advisor doesn't automatically refresh without a human either hitting a button or making a set of API calls.

This PR is a first stab at writing a super simple Go script to refresh Trusted Advisor and also make it run in lambda. I've tested running in lambda by running 
```
pushd pushd lambda/trusted-advisor-refresh 
GOOS=linux go build -o main     
zip trusted-advisor-refresh.zip main
```
And uploading the zip to Lambda.

The thing I haven't figured out is a good way to plum this into a build process. Maybe it's time for CircleCI. 