### PR TITLE
Lambda function to copy RDS logs to CloudWatch

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -33,6 +33,7 @@
     "aws/signer/v4",
     "internal/sdkio",
     "internal/sdkrand",
+    "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/ec2query",
@@ -46,26 +47,28 @@
     "private/protocol/restxml",
     "private/protocol/xml/xmlutil",
     "service/cloudwatch",
+    "service/cloudwatchlogs",
     "service/ec2",
+    "service/iam",
     "service/rds",
     "service/s3",
     "service/sts",
     "service/support"
   ]
-  revision = "c9af76f2478f81c6566d0f7f4d522254ec7c0b52"
-  version = "v1.14.3"
+  revision = "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4"
+  version = "v1.14.33"
 
 [[projects]]
-  name = "github.com/caarlos0/env"
+  branch = "master"
+  name = "github.com/ejholmes/cloudwatch"
   packages = ["."]
-  revision = "1cddc31c48c56ecd700d873edb9fd5b6f5df922a"
-  version = "v3.3.0"
+  revision = "c2bae568a25431c6c82170dd18361a478bd1f1b5"
 
 [[projects]]
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5"
-  version = "v1.37.0"
+  revision = "358ee7663966325963d4e8b2e1fbd570c5195153"
+  version = "v1.38.1"
 
 [[projects]]
   name = "github.com/jessevdk/go-flags"
@@ -86,7 +89,7 @@
     "formatter",
     "parser"
   ]
-  revision = "d0a98937db5130acbf4231fe8bd3897fe10a7ac7"
+  revision = "385fac0ced9acaae6dc5b39144194008ded00697"
 
 [[projects]]
   name = "go.uber.org/atomic"
@@ -110,12 +113,12 @@
     "internal/exit",
     "zapcore"
   ]
-  revision = "eeedf312bc6c57391d84767a4cd413f02a917974"
-  version = "v1.8.0"
+  revision = "4d45f9617f7d90f7a663ff21c7a4321dbe78098b"
+  version = "v1.9.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "9f536aeb8af7a85535b98849eeeba0560edea075aa8f0e93c813f9dd08b2162b"
+  inputs-digest = "57bffe5d6fcbbb0dbeec6b20a669abdf52e2cf0ba36c639a4484f3942aadc0c4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/sh
-VERSION = 2.0
+VERSION = 2.1
 
 all: install
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ AWS tools that come in handy.
 |-------------------------|----------------------------------------------------------------------------------------------------------|---------------------|
 | ebs-delete              | snapshots an EBS volume before deleting, and won't delete volumes that belong to CloudFormation stacks.  | No                  |
 | iam-keys-check          | checks users for old access keys and sends notification to a slack webhook url                           | Yes                 |
+| rds-cloudwatch-logs     | Streams logs from RDS into CloudWatch Logs. This is only really needed for PostgreSQL, until AWS makes it a proper service| Yes |
 | rds-snapshot-cleaner    | removes manual snapshot for a RDS instance that are older than X days or over a maximum snapshot count.  | Yes                 |
 | s3-bucket-size          | figures out how many bytes are in a given bucket as of the last CloudWatch metric update. Must faster and cheaper than iterating over all of the objects and usually "good enough". | No |
 | trusted-advisor-refresh | triggers a refresh of Trusted Advisor because AWS doesn't do this for you.                               | Yes                 |

--- a/bin/make-lambda-build
+++ b/bin/make-lambda-build
@@ -11,7 +11,7 @@ cleanup() {
 trap "cleanup" EXIT INT
 
 readonly build_dir=$(mktemp -d)
-readonly lambda_tools="rds-snapshot-cleaner trusted-advisor-refresh iam-keys-check"
+readonly lambda_tools="rds-snapshot-cleaner trusted-advisor-refresh iam-keys-check rds-cloudwatch-logs"
 mkdir -p "$build_dir"
 
 for cmd in $lambda_tools

--- a/cmd/rds-cloudwatch-logs/main.go
+++ b/cmd/rds-cloudwatch-logs/main.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/trussworks/truss-aws-tools/internal/aws/session"
+	"github.com/trussworks/truss-aws-tools/pkg/rdscwlogs"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/rds"
+	flag "github.com/jessevdk/go-flags"
+	"go.uber.org/zap"
+)
+
+// Options are the command line options
+type Options struct {
+	CloudWatchLogsGroup  string `long:"cloudwatch-logs-group" description:"The CloudWatch Log group name." required:"true" env:"CLOUDWATCH_LOGS_GROUP"`
+	DBInstanceIdentifier string `long:"db-instance-identifier" description:"The RDS database instance identifier." required:"true" env:"DB_INSTANCE_IDENTIFIER"`
+	Lambda               bool   `long:"lambda" description:"Run as an AWS lambda function." required:"false" env:"LAMBDA"`
+	Profile              string `long:"profile" description:"The AWS profile to use." required:"false" env:"PROFILE"`
+	Region               string `long:"region" description:"The AWS region to use." required:"false" env:"REGION"`
+	StartTime            string `long:"start-time" description:"The log file start time." required:"true" choice:"1h" choice:"1d" env:"START_TIME"`
+}
+
+var options Options
+var logger *zap.Logger
+
+func makeCloudWatchLogsClient(region, profile string) *cloudwatchlogs.CloudWatchLogs {
+	sess := session.MustMakeSession(region, profile)
+	cloudWatchLogsClient := cloudwatchlogs.New(sess)
+	return cloudWatchLogsClient
+}
+
+func makeRDSClient(region, profile string) *rds.RDS {
+	sess := session.MustMakeSession(region, profile)
+	rdsClient := rds.New(sess)
+	return rdsClient
+}
+
+func sendLogs() {
+	r := rdscwlogs.RDSCloudWatchLogs{
+		DBInstanceIdentifier: options.DBInstanceIdentifier,
+		CloudWatchLogsClient: makeCloudWatchLogsClient(options.Region, options.Profile),
+		CloudWatchLogsGroup:  options.CloudWatchLogsGroup,
+		Logger:               logger,
+		RDSClient:            makeRDSClient(options.Region, options.Profile),
+	}
+
+	var since int64
+	if options.StartTime == "1h" {
+		since = time.Now().Add(-1*time.Hour).Unix() * 1000
+	} else if options.StartTime == "1d" {
+		since = time.Now().Add(-24*time.Hour).Unix() * 1000
+	}
+
+	mostRecentDBLogFile, err := r.GetMostRecentLogFile()
+	if err != nil {
+		logger.Fatal("unable to find most recent rds log file",
+			zap.Error(err))
+	}
+
+	dbLogFiles, err := r.GetLogFilesSince(since)
+	if err != nil {
+		logger.Fatal("unable to get rds log files", zap.Error(err))
+	}
+	for i := range dbLogFiles {
+		dbLogFile := dbLogFiles[i]
+		if *dbLogFile.LogFileName == *mostRecentDBLogFile.LogFileName {
+			logger.Info("skipping most recent db log file",
+				zap.String("db_log_file_name", *mostRecentDBLogFile.LogFileName))
+			continue
+		}
+		err = r.SendRDSLogFile(*dbLogFile.LogFileName)
+		if err != nil {
+			logger.Error("unable to send rds log file to cloudWatch logs",
+				zap.Error(err))
+		}
+	}
+}
+
+func lambdaHandler() {
+	lambda.Start(sendLogs)
+}
+
+func main() {
+	parser := flag.NewParser(&options, flag.Default)
+	_, err := parser.Parse()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	logger, err = zap.NewProduction()
+	if err != nil {
+		log.Fatalf("can't initialize zap logger: %v", err)
+	}
+
+	if options.Lambda {
+		logger.Info("Running Lambda handler.")
+		lambdaHandler()
+	} else {
+		sendLogs()
+	}
+
+}

--- a/pkg/rdscwlogs/rds_cloudwatch_logs.go
+++ b/pkg/rdscwlogs/rds_cloudwatch_logs.go
@@ -1,0 +1,128 @@
+package rdscwlogs
+
+import (
+	"errors"
+	"io"
+	"sort"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/ejholmes/cloudwatch"
+	"go.uber.org/zap"
+)
+
+// RDSCloudWatchLogs defines parameters streaming RDS logs to
+// CloudWatch Logs
+type RDSCloudWatchLogs struct {
+	DBInstanceIdentifier string
+	CloudWatchLogsClient *cloudwatchlogs.CloudWatchLogs
+	CloudWatchLogsGroup  string
+	Logger               *zap.Logger
+	RDSClient            *rds.RDS
+}
+
+// GetMostRecentLogFile returns the most recent log file that the RDS instance is currently
+// writing too
+func (r *RDSCloudWatchLogs) GetMostRecentLogFile() (recentDBLogFile *rds.DescribeDBLogFilesDetails, err error) {
+	dbLogFiles, err := r.GetLogFilesSince(0)
+	if err != nil {
+		return
+	}
+	if len(dbLogFiles) == 0 {
+		err = errors.New("no log files found")
+		return
+
+	}
+	sort.SliceStable(dbLogFiles, func(i, j int) bool { return *dbLogFiles[i].LastWritten < *dbLogFiles[j].LastWritten })
+
+	recentDBLogFile = dbLogFiles[len(dbLogFiles)-1]
+	return
+}
+
+// GetLogFilesSince returns RDS log files last written since the provided in Unix stamp
+func (r *RDSCloudWatchLogs) GetLogFilesSince(since int64) (logFiles []*rds.DescribeDBLogFilesDetails, err error) {
+	input := &rds.DescribeDBLogFilesInput{
+		DBInstanceIdentifier: aws.String(r.DBInstanceIdentifier),
+		FileLastWritten:      aws.Int64(since),
+	}
+
+	err = r.RDSClient.DescribeDBLogFilesPages(input, func(p *rds.DescribeDBLogFilesOutput, lastPage bool) bool {
+		logFiles = append(logFiles, p.DescribeDBLogFiles...)
+		return true
+	})
+
+	return
+
+}
+
+// DownloadDBLogFile will download in a paginated fashion. The specified RDS log file is written to the provided io.Writer
+func (r *RDSCloudWatchLogs) DownloadDBLogFile(w io.Writer, logFileName string) error {
+	input := &rds.DownloadDBLogFilePortionInput{
+		DBInstanceIdentifier: aws.String(r.DBInstanceIdentifier),
+		LogFileName:          aws.String(logFileName),
+		Marker:               aws.String("0"),
+		NumberOfLines:        aws.Int64(10000),
+	}
+	for {
+		result, err := r.RDSClient.DownloadDBLogFilePortion(input)
+		if err != nil {
+			return err
+		}
+
+		if result.LogFileData != nil && *result.LogFileData != "" {
+			_, err := w.Write([]byte(aws.StringValue(result.LogFileData)))
+			if err != nil {
+				return err
+			}
+		}
+
+		if !*result.AdditionalDataPending {
+			return nil
+		}
+		input.Marker = aws.String(*result.Marker)
+	}
+}
+
+// SendRDSLogFile streams log file from RDS to CloudWatch Logs
+func (r *RDSCloudWatchLogs) SendRDSLogFile(logFileName string) error {
+	g := cloudwatch.NewGroup(r.CloudWatchLogsGroup, r.CloudWatchLogsClient)
+	w, err := g.Create(logFileName)
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			switch aerr.Code() {
+			case cloudwatchlogs.ErrCodeResourceAlreadyExistsException:
+				r.Logger.Warn("cloudwatch log stream already exists",
+					zap.String("cloudwatch_logs_stream", logFileName))
+				return nil
+			default:
+				return err
+			}
+		}
+		return err
+	}
+	r.Logger.Info("creating new cloudwatch log stream",
+		zap.String("cloudwatch_logs_group", r.CloudWatchLogsGroup),
+		zap.String("cloudwatch_logs_stream", logFileName))
+
+	defer func(w io.Writer) {
+		// Ensure we flush any remaining buffered logs to stream
+		r.Logger.Info("writing logs to cloudwatch logs",
+			zap.String("cloudwatch_logs_group", r.CloudWatchLogsGroup),
+			zap.String("cloudwatch_logs_stream", logFileName))
+		if writer, ok := w.(*cloudwatch.Writer); ok {
+			if err := writer.Flush(); err != nil {
+				r.Logger.Error("unable to flush logs", zap.Error(err))
+			}
+		}
+	}(w)
+	r.Logger.Info("downloading rds log file",
+		zap.String("db_instance_identifier", r.DBInstanceIdentifier),
+		zap.String("rds_log_file", logFileName))
+	err = r.DownloadDBLogFile(w, logFileName)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Since RDS still hasn't added the ability to copy RDS logs into CloudWatch for PostgreSQL, this PR adds a Lambda function to fill that gap. The tool will stream the logs files for the last hour or last day into CloudWatch Logs. For the time being, it does not copy the current log file because CloudWatch Logs are append only and that would have meant paying attention to previous state and I'm more interested the retention issues around RDS logs.   

**Testing**

- [x] Local testing
```
rds-cloudwatch-logs --db-instance-identifier app-experimental --cloudwatch-logs-group dyna-test --region us-west-2
{"level":"info","ts":1532641479.0124998,"caller":"rdscwlogs/rds_cloudwatch_logs.go:120","msg":"downloading rds log file","db_instance_identifier":"app-experimental","rds_log_file":"error/postgresql.log.2018-07-26-20"}
{"level":"info","ts":1532641479.081198,"caller":"rdscwlogs/rds_cloudwatch_logs.go:111","msg":"writing logs to cloudwatch logs","cloudwatch_logs_group":"dyna-test","cloudwatch_logs_stream":"error/postgresql.log.2018-07-26-20"}
{"level":"info","ts":1532641479.144989,"caller":"rds-cloudwatch-logs/main.go:66","msg":"skipping most recent db log file","db_log_file_name":"error/postgresql.log.2018-07-26-21"}
```

- [x] Run in Lambda
