### PR TITLE
Lambda function to send AWS health events to Slack

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,16 +2,20 @@
 
 
 [[projects]]
+  digest = "1:8b55da6790eeade578c1fd4ebaa5b0e641072172e1d743f3cb945ae73af463f9"
   name = "github.com/aws/aws-lambda-go"
   packages = [
+    "events",
     "lambda",
     "lambda/messages",
-    "lambdacontext"
+    "lambdacontext",
   ]
-  revision = "4d30d0ff60440c2d0480a15747c96ee71c3c53d4"
-  version = "v1.2.0"
+  pruneopts = ""
+  revision = "2d482ef09017ae953b1e8d5a6ddac5b696663a3c"
+  version = "v1.6.0"
 
 [[projects]]
+  digest = "1:4a54b6f95f4f0bbbcb80ead2435a113ab0e2bda09c6e652e3ad864ccc7777714"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -31,6 +35,7 @@
     "aws/request",
     "aws/session",
     "aws/signer/v4",
+    "internal/s3err",
     "internal/sdkio",
     "internal/sdkrand",
     "internal/sdkuri",
@@ -52,58 +57,115 @@
     "service/iam",
     "service/rds",
     "service/s3",
+    "service/ssm",
     "service/sts",
-    "service/support"
+    "service/support",
   ]
-  revision = "96313df4b1ba47ade3de7b2b90d69c02a81ddaa4"
-  version = "v1.14.33"
+  pruneopts = ""
+  revision = "c35fe9d06b9f0cefe538ecdb7501c84603119dfb"
+  version = "v1.15.56"
+
+[[projects]]
+  digest = "1:0deddd908b6b4b768cfc272c16ee61e7088a60f7fe2f06c547bd3d8e1f8b8e77"
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  pruneopts = ""
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:c44fdb7c1dbbca20d53278e6a048ddb110331b4d4753c08dea44938902b4f7d8"
   name = "github.com/ejholmes/cloudwatch"
   packages = ["."]
+  pruneopts = ""
   revision = "c2bae568a25431c6c82170dd18361a478bd1f1b5"
 
 [[projects]]
+  digest = "1:736253aac975cfc002b3c74034b8ff6becac84ed92e91b6147f6703834b890cc"
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "358ee7663966325963d4e8b2e1fbd570c5195153"
-  version = "v1.38.1"
+  pruneopts = ""
+  revision = "9c8236e659b76e87bf02044d06fde8683008ff3e"
+  version = "v1.39.0"
 
 [[projects]]
+  digest = "1:ca5c90960520407749b98c49650f54f5f90a667796e85c5ee1597478f702fb91"
   name = "github.com/jessevdk/go-flags"
   packages = ["."]
+  pruneopts = ""
   revision = "c6ca198ec95c841fdb89fc0de7496fed11ab854e"
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = ""
   revision = "0b12d6b5"
 
 [[projects]]
   branch = "master"
+  digest = "1:315caae2cd60c5894ffdf9cc9302f878bb5cdd30749de250aa6e29663b60b708"
   name = "github.com/jstemmer/go-junit-report"
   packages = [
     ".",
     "formatter",
-    "parser"
+    "parser",
   ]
+  pruneopts = ""
   revision = "385fac0ced9acaae6dc5b39144194008ded00697"
 
 [[projects]]
+  branch = "master"
+  digest = "1:216f1a2d697f66c55f000cd78aa7f53f21134eda20ae972c8f98a921d209d90a"
+  name = "github.com/lytics/slackhook"
+  packages = ["."]
+  pruneopts = ""
+  revision = "a52fd449b27dcdd75cf069c5d6ac5749653d801a"
+
+[[projects]]
+  digest = "1:7365acd48986e205ccb8652cc746f09c8b7876030d53710ea6ef7d0bd0dcd7ca"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = ""
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
+  digest = "1:256484dbbcd271f9ecebc6795b2df8cad4c458dd0f5fd82a8c2fa0c29f233411"
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  pruneopts = ""
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  digest = "1:c587772fb8ad29ad4db67575dad25ba17a51f072ff18a22b4f0257a4d9c24f75"
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  pruneopts = ""
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
+
+[[projects]]
+  digest = "1:74f86c458e82e1c4efbab95233e0cf51b7cc02dc03193be9f62cd81224e10401"
   name = "go.uber.org/atomic"
   packages = ["."]
+  pruneopts = ""
   revision = "1ea20fb1cbb1cc08cbd0d913a96dead89aa18289"
   version = "v1.3.2"
 
 [[projects]]
+  digest = "1:22c7effcb4da0eacb2bb1940ee173fac010e9ef3c691f5de4b524d538bd980f5"
   name = "go.uber.org/multierr"
   packages = ["."]
+  pruneopts = ""
   revision = "3c4937480c32f4c13a875a1829af76c98ca3d40a"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:246f378f80fba6fcf0f191c486b6613265abd2bc0f2fa55a36b928c67352021e"
   name = "go.uber.org/zap"
   packages = [
     ".",
@@ -111,14 +173,36 @@
     "internal/bufferpool",
     "internal/color",
     "internal/exit",
-    "zapcore"
+    "zapcore",
   ]
-  revision = "4d45f9617f7d90f7a663ff21c7a4321dbe78098b"
-  version = "v1.9.0"
+  pruneopts = ""
+  revision = "ff33455a0e382e8a81d14dd7c922020b6b5e7982"
+  version = "v1.9.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "57bffe5d6fcbbb0dbeec6b20a669abdf52e2cf0ba36c639a4484f3942aadc0c4"
+  input-imports = [
+    "github.com/aws/aws-lambda-go/events",
+    "github.com/aws/aws-lambda-go/lambda",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/awserr",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/cloudwatch",
+    "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
+    "github.com/aws/aws-sdk-go/service/ec2",
+    "github.com/aws/aws-sdk-go/service/iam",
+    "github.com/aws/aws-sdk-go/service/rds",
+    "github.com/aws/aws-sdk-go/service/s3",
+    "github.com/aws/aws-sdk-go/service/ssm",
+    "github.com/aws/aws-sdk-go/service/support",
+    "github.com/ejholmes/cloudwatch",
+    "github.com/jessevdk/go-flags",
+    "github.com/jstemmer/go-junit-report",
+    "github.com/lytics/slackhook",
+    "github.com/pkg/errors",
+    "github.com/stretchr/testify/assert",
+    "go.uber.org/zap",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/sh
-VERSION = 2.2
+VERSION = 2.3
 
 all: install
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ AWS tools that come in handy.
 | Tool                    | Description                                                                                              | AWS Lambda Support  |
 |-------------------------|----------------------------------------------------------------------------------------------------------|---------------------|
 | ebs-delete              | snapshots an EBS volume before deleting, and won't delete volumes that belong to CloudFormation stacks.  | No                  |
-| iam-keys-check          | checks users for old access keys and sends notification to a slack webhook url                           | Yes                 |
+| iam-keys-check          | checks users for old access keys and sends notification to a Slack webhook url                           | Yes                 |
 | rds-cloudwatch-logs     | Streams logs from RDS into CloudWatch Logs. This is only really needed for PostgreSQL, until AWS makes it a proper service| Yes |
 | rds-snapshot-cleaner    | removes manual snapshot for a RDS instance that are older than X days or over a maximum snapshot count.  | Yes                 |
 | s3-bucket-size          | figures out how many bytes are in a given bucket as of the last CloudWatch metric update. Must faster and cheaper than iterating over all of the objects and usually "good enough". | No |
 | trusted-advisor-refresh | triggers a refresh of Trusted Advisor because AWS doesn't do this for you.                               | Yes                 |
+| aws-health-notifier     | Sends notifcations to a Slack webhook when AWS Health Events (read AWS outage) are triggered             | Yes                 |
 
 ## Installation
 

--- a/bin/make-lambda-build
+++ b/bin/make-lambda-build
@@ -11,7 +11,7 @@ cleanup() {
 trap "cleanup" EXIT INT
 
 readonly build_dir=$(mktemp -d)
-readonly lambda_tools="rds-snapshot-cleaner trusted-advisor-refresh iam-keys-check rds-cloudwatch-logs"
+readonly lambda_tools="rds-snapshot-cleaner trusted-advisor-refresh iam-keys-check rds-cloudwatch-logs aws-health-notifier"
 mkdir -p "$build_dir"
 
 for cmd in $lambda_tools

--- a/cmd/aws-health-notifier/main.go
+++ b/cmd/aws-health-notifier/main.go
@@ -38,7 +38,7 @@ func sendNotification(event events.CloudWatchEvent) {
 	awsSession := session.MustMakeSession(options.Region, options.Profile)
 	slackWebhookURL, err := ssm.DecryptValue(awsSession, options.SSMSlackWebhookURL)
 	if err != nil {
-		log.Fatal("failed to decrypt slackWebhookURL", zap.Error(err))
+		logger.Fatal("failed to decrypt slackWebhookURL", zap.Error(err))
 	}
 	slack := slackhook.New(slackWebhookURL)
 
@@ -86,18 +86,18 @@ func lambdaHandler() {
 }
 
 func main() {
-	parser := flag.NewParser(&options, flag.Default)
-	_, err := parser.Parse()
-	if err != nil {
-		log.Fatal(err)
-	}
-
+	var err error
 	logger, err = zap.NewProduction()
 	if err != nil {
 		log.Fatalf("can't initialize zap logger: %v", err)
 	}
+	parser := flag.NewParser(&options, flag.Default)
+
+	_, err = parser.Parse()
+	if err != nil {
+		logger.Fatal("failed to parse flags", zap.Error(err))
+	}
 
 	logger.Info("Running Lambda handler.")
 	lambdaHandler()
-
 }

--- a/cmd/aws-health-notifier/main.go
+++ b/cmd/aws-health-notifier/main.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/trussworks/truss-aws-tools/internal/aws/session"
+	"github.com/trussworks/truss-aws-tools/internal/aws/ssm"
+	"github.com/trussworks/truss-aws-tools/pkg/awshealth"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+	flag "github.com/jessevdk/go-flags"
+	"github.com/lytics/slackhook"
+	"go.uber.org/zap"
+)
+
+// Options are the command line options
+type Options struct {
+	Region             string `long:"region" description:"The AWS region to use." required:"false" env:"REGION"`
+	Profile            string `short:"p" long:"profile" description:"The AWS profile to use." required:"false" env:"AWS_PROFILE"`
+	SlackChannel       string `long:"slack-channel" description:"The Slack channel." required:"true" env:"SLACK_CHANNEL"`
+	SlackEmoji         string `long:"slack-emoji" description:"The Slack Emoji associated with the notifications." env:"SLACK_EMOJI" default:":boom:"`
+	SSMSlackWebhookURL string `long:"ssm-slack-webhook-url" description:"The name of the Slack Webhook Url in Parameter store." required:"false" env:"SSM_SLACK_WEBHOOK_URL"`
+}
+
+var options Options
+var logger *zap.Logger
+
+func sendNotification(event events.CloudWatchEvent) {
+	var health awshealth.Event
+	err := json.Unmarshal([]byte(event.Detail), &health)
+	if err != nil {
+		logger.Error("Unable to unmarshal health event", zap.Error(err))
+	}
+
+	eventURL := health.HealthEventURL()
+	awsSession := session.MustMakeSession(options.Region, options.Profile)
+	slackWebhookURL, err := ssm.DecryptValue(awsSession, options.SSMSlackWebhookURL)
+	if err != nil {
+		log.Fatal("failed to decrypt slackWebhookURL", zap.Error(err))
+	}
+	slack := slackhook.New(slackWebhookURL)
+
+	attachment := slackhook.Attachment{
+		Title:     "AWS Health Notification",
+		TitleLink: awshealth.PersonalHealthDashboardURL,
+		Color:     "danger",
+		Fields: []slackhook.Field{
+			{
+				Title: "Service",
+				Value: health.Service,
+			},
+			{
+				Title: "Description",
+				Value: health.Description[0].Latest,
+			},
+			{
+				Title: "EventTypeCode",
+				Value: health.EventTypeCode,
+			},
+			{
+				Title: "Link",
+				Value: eventURL,
+				Short: false,
+			},
+		},
+	}
+
+	message := &slackhook.Message{
+		Channel:   options.SlackChannel,
+		IconEmoji: options.SlackEmoji,
+	}
+	message.AddAttachment(&attachment)
+
+	err = slack.Send(message)
+	if err != nil {
+		logger.Error("failed to send slack message", zap.Error(err),
+			zap.String("slack-channel", options.SlackChannel))
+	}
+	logger.Info("successfully sent slack message", zap.String("slack-channel", options.SlackChannel))
+}
+
+func lambdaHandler() {
+	lambda.Start(sendNotification)
+}
+
+func main() {
+	parser := flag.NewParser(&options, flag.Default)
+	_, err := parser.Parse()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	logger, err = zap.NewProduction()
+	if err != nil {
+		log.Fatalf("can't initialize zap logger: %v", err)
+	}
+
+	logger.Info("Running Lambda handler.")
+	lambdaHandler()
+
+}

--- a/internal/aws/ssm/ssm.go
+++ b/internal/aws/ssm/ssm.go
@@ -1,0 +1,34 @@
+package ssm
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ssm"
+	"github.com/pkg/errors"
+)
+
+// DecryptValue returns the decrypted value for a Parameter Store key
+func DecryptValue(session *session.Session, parameterStoreKey string) (string, error) {
+	ssmClient := ssm.New(session)
+	getParameterOutput, err := ssmClient.GetParameter(&ssm.GetParameterInput{
+		Name:           aws.String(parameterStoreKey),
+		WithDecryption: aws.Bool(true),
+	})
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok {
+			if aerr.Code() == ssm.ErrCodeInternalServerError {
+				return "", errors.Wrap(err, "ssm appeared to have an internal error")
+			} else if aerr.Code() == ssm.ErrCodeInvalidKeyId || aerr.Code() == ssm.ErrCodeParameterNotFound || aerr.Code() == ssm.ErrCodeParameterVersionNotFound {
+				return "", errors.Wrap(err, "the provided patameter store key appears to be invalid")
+			} else {
+				return "", errors.Wrap(err, "unknown AWS error")
+			}
+		}
+		return "", errors.Wrap(err, "unknown error getting ssm parameter")
+	}
+	if getParameterOutput.Parameter.Value == nil {
+		return "", errors.Wrap(err, "ssm parameter value is nil")
+	}
+	return *getParameterOutput.Parameter.Value, nil
+}

--- a/pkg/awshealth/aws_health_event.go
+++ b/pkg/awshealth/aws_health_event.go
@@ -1,0 +1,28 @@
+package awshealth
+
+import (
+	"fmt"
+)
+
+// PersonalHealthDashboardURL is the URL to view AWS's Personal Health Dashboard
+const PersonalHealthDashboardURL = "https://phd.aws.amazon.com/phd/home"
+
+// EventDescription is AWS Health Event Descripion
+type EventDescription struct {
+	Language string `json:"language"`
+	Latest   string `json:"latestDescription"`
+}
+
+// Event defines relevant info out of the json payload from AWS Personal Health
+type Event struct {
+	Description       []EventDescription `json:"eventDescription"`
+	EventARN          string             `json:"eventArn"`
+	EventTypeCategory string             `json:"eventTypeCategory"`
+	EventTypeCode     string             `json:"eventTypeCode"`
+	Service           string             `json:"service"`
+}
+
+// HealthEventURL returns the unique unescaped URL asscociated with an AWS health event
+func (h *Event) HealthEventURL() string {
+	return fmt.Sprintf("%s#/dashboard/open-issues?eventID=%s&eventTab=details&layout=horizontal", PersonalHealthDashboardURL, h.EventARN)
+}


### PR DESCRIPTION
Add a new Lambda function, which will notify Slack if there's an AWS outage. It uses the health API, which should send events impacting the AWS account. 

![image](https://user-images.githubusercontent.com/675823/47121252-d5a8cd80-d226-11e8-83a9-162bd41aa57a.png)
