### PR TITLE
extend s3 buck size tool to take new storage classes into account

### DIFF
--- a/cmd/s3-bucket-size/main.go
+++ b/cmd/s3-bucket-size/main.go
@@ -84,6 +84,12 @@ func getBucketSize(c *cloudwatch.CloudWatch, bucket string) (int, error) {
 		standardStorage,
 		standardIAStorage,
 		reducedRedundancyStorage,
+		glacierS3ObjectOverhead,
+		standardIAObjectOverhead,
+		oneZoneIAStorage,
+		oneZoneIAObjectOverhead,
+		glacierStorage,
+		glacierObjectOverhead,
 	}
 	size := 0
 	for _, storageType := range storageTypes {
@@ -125,6 +131,12 @@ const (
 	standardStorage cloudWatchStorageType = iota
 	standardIAStorage
 	reducedRedundancyStorage
+	glacierS3ObjectOverhead
+	standardIAObjectOverhead
+	oneZoneIAStorage
+	oneZoneIAObjectOverhead
+	glacierStorage
+	glacierObjectOverhead
 )
 
 func makeGetMetricStatisticsInputForSize(bucket string, storageType cloudWatchStorageType) *cloudwatch.GetMetricStatisticsInput {
@@ -136,6 +148,18 @@ func makeGetMetricStatisticsInputForSize(bucket string, storageType cloudWatchSt
 		storageTypeString = "StandardIAStorage"
 	case reducedRedundancyStorage:
 		storageTypeString = "ReducedRedundancyStorage"
+	case glacierS3ObjectOverhead:
+		storageTypeString = "GlacierS3ObjectOverhead"
+	case standardIAObjectOverhead:
+		storageTypeString = "StandardIAObjectOverhead"
+	case oneZoneIAStorage:
+		storageTypeString = "OneZoneIAStorage"
+	case oneZoneIAObjectOverhead:
+		storageTypeString = "OneZoneIAObjectOverhead"
+	case glacierStorage:
+		storageTypeString = "GlacierStorage"
+	case glacierObjectOverhead:
+		storageTypeString = "GlacierObjectOverhead"
 	}
 	now := time.Now()
 	// CloudWatch daily metrics can take some time to

--- a/cmd/s3-bucket-size/main.go
+++ b/cmd/s3-bucket-size/main.go
@@ -84,12 +84,8 @@ func getBucketSize(c *cloudwatch.CloudWatch, bucket string) (int, error) {
 		standardStorage,
 		standardIAStorage,
 		reducedRedundancyStorage,
-		glacierS3ObjectOverhead,
-		standardIAObjectOverhead,
 		oneZoneIAStorage,
-		oneZoneIAObjectOverhead,
 		glacierStorage,
-		glacierObjectOverhead,
 	}
 	size := 0
 	for _, storageType := range storageTypes {
@@ -131,12 +127,8 @@ const (
 	standardStorage cloudWatchStorageType = iota
 	standardIAStorage
 	reducedRedundancyStorage
-	glacierS3ObjectOverhead
-	standardIAObjectOverhead
 	oneZoneIAStorage
-	oneZoneIAObjectOverhead
 	glacierStorage
-	glacierObjectOverhead
 )
 
 func makeGetMetricStatisticsInputForSize(bucket string, storageType cloudWatchStorageType) *cloudwatch.GetMetricStatisticsInput {
@@ -148,18 +140,10 @@ func makeGetMetricStatisticsInputForSize(bucket string, storageType cloudWatchSt
 		storageTypeString = "StandardIAStorage"
 	case reducedRedundancyStorage:
 		storageTypeString = "ReducedRedundancyStorage"
-	case glacierS3ObjectOverhead:
-		storageTypeString = "GlacierS3ObjectOverhead"
-	case standardIAObjectOverhead:
-		storageTypeString = "StandardIAObjectOverhead"
 	case oneZoneIAStorage:
 		storageTypeString = "OneZoneIAStorage"
-	case oneZoneIAObjectOverhead:
-		storageTypeString = "OneZoneIAObjectOverhead"
 	case glacierStorage:
 		storageTypeString = "GlacierStorage"
-	case glacierObjectOverhead:
-		storageTypeString = "GlacierObjectOverhead"
 	}
 	now := time.Now()
 	// CloudWatch daily metrics can take some time to


### PR DESCRIPTION
New storage types added:
* oneZoneIAStorage
* glacierStorage

------------------------------------
The bucket `truss-office-printer1` contains 8 total files (in different storage types as seen in screenshot below) 

* 7 files each of size `10485760`
* one file with a size of `645` and 4 folders

Tested against `truss-office-printer1` bucket using command `s3-bucket-size --bucket=truss-office-printer1 --region=us-west-2`:
![image](https://user-images.githubusercontent.com/5003421/47440075-7f361480-d77b-11e8-9a71-407c79c512d6.png)

![image](https://user-images.githubusercontent.com/5003421/47440702-b0fbab00-d77c-11e8-9588-91edae8f8f81.png)




(10485760*7)+645= 73400965 ~= 73401519 (I believe the 554 diff is coming from metadata)

------------------------------------------------------------
Glacier example: 
-----------------
![image](https://user-images.githubusercontent.com/5003421/47512194-a4915400-d849-11e8-813a-76d1bb92f2d5.png)
