### PR TITLE
Cg fix lambda functions

### DIFF
--- a/cmd/aws-health-notifier/main.go
+++ b/cmd/aws-health-notifier/main.go
@@ -41,6 +41,10 @@ func sendNotification(event events.CloudWatchEvent) {
 		logger.Fatal("failed to decrypt slackWebhookURL", zap.Error(err))
 	}
 	slack := slackhook.New(slackWebhookURL)
+	description := "no description found in health check"
+	if len(health.Description) > 0 {
+		description = health.Description[0].Latest
+	}
 
 	attachment := slackhook.Attachment{
 		Title:     "AWS Health Notification",
@@ -53,7 +57,7 @@ func sendNotification(event events.CloudWatchEvent) {
 			},
 			{
 				Title: "Description",
-				Value: health.Description[0].Latest,
+				Value: description,
 			},
 			{
 				Title: "EventTypeCode",

--- a/gometalinter.json
+++ b/gometalinter.json
@@ -1,5 +1,6 @@
 {
   "aggregate": true,
+  "deadline": "90s",
   "disable": [
     "gocyclo",
     "gosec",


### PR DESCRIPTION
## Description

I tried invoking a lambda function and got an error.  Looks like it probably has to do with no health notifications being present but I still felt like we should catch this kind of bug.

## Details

Invoking the function:

```
aws lambda invoke --function-name aws-health-notifier-prod outfile.txt && cat outfile.txt | jq .
```

Returned this error:

```
{
    "StatusCode": 200,
    "FunctionError": "Unhandled",
    "ExecutedVersion": "$LATEST"
}
```

The output had this in it:

```
{
  "errorMessage": "runtime error: index out of range",
  "errorType": "errorString",
  "stackTrace": [
    {
      "path": "github.com/trussworks/truss-aws-tools/vendor/github.com/aws/aws-lambda-go/lambda/function.go",
      "line": 27,
      "label": "(*Function).Invoke.func1"
    },
    {
      "path": "runtime/asm_amd64.s",
      "line": 522,
      "label": "call32"
    },
    {
      "path": "runtime/panic.go",
      "line": 513,
      "label": "gopanic"
    },
    {
      "path": "runtime/panic.go",
      "line": 44,
      "label": "panicindex"
    },
    {
      "path": "aws-health-notifier/main.go",
      "line": 56,
      "label": "sendNotification"
    },
    {
      "path": "runtime/asm_amd64.s",
      "line": 525,
      "label": "call256"
    },
    {
      "path": "reflect/value.go",
      "line": 447,
      "label": "Value.call"
    },
    {
      "path": "reflect/value.go",
      "line": 308,
      "label": "Value.Call"
    },
    {
      "path": "github.com/trussworks/truss-aws-tools/vendor/github.com/aws/aws-lambda-go/lambda/handler.go",
      "line": 114,
      "label": "NewHandler.func1"
    },
    {
      "path": "github.com/trussworks/truss-aws-tools/vendor/github.com/aws/aws-lambda-go/lambda/handler.go",
      "line": 22,
      "label": "lambdaHandler.Invoke"
    },
    {
      "path": "github.com/trussworks/truss-aws-tools/vendor/github.com/aws/aws-lambda-go/lambda/function.go",
      "line": 59,
      "label": "(*Function).Invoke"
    },
    {
      "path": "runtime/asm_amd64.s",
      "line": 523,
      "label": "call64"
    },
    {
      "path": "reflect/value.go",
      "line": 447,
      "label": "Value.call"
    },
    {
      "path": "reflect/value.go",
      "line": 308,
      "label": "Value.Call"
    },
    {
      "path": "net/rpc/server.go",
      "line": 384,
      "label": "(*service).call"
    },
    {
      "path": "runtime/asm_amd64.s",
      "line": 1333,
      "label": "goexit"
    }
  ]
}
```