### PR TITLE
amicleaner utility

### DIFF
--- a/cmd/ami-cleaner/main.go
+++ b/cmd/ami-cleaner/main.go
@@ -15,12 +15,13 @@ import (
 
 // The Options struct describes the command line options available.
 type Options struct {
-	DryRun        bool   `short:"n" long:"dryrun" description:"Run in dryrun mode (ie, do not actually purge AMIs)."`
+	Delete        bool   `short:"D" long:"delete" description:"Actually purge AMIs (runs in dryrun mode by default)."`
 	RetentionDays int    `long:"days" default:"30" description:"Age of AMI in days before it is a candidate for removal."`
-	Branch        string `short:"b" long:"branch" description:"Branch to purge.  Preface with ! to purge all branches *but* this one (eg, !master would purge all AMIs not from the master branch)."`
+	Branch        string `short:"b" long:"branch" required:"true" description:"Branch to purge. If the the --exclude option is used, this is the branch NOT to operate on."`
+	Invert        bool   `short:"i" long:"invert" description:"Operate in inverted mode -- only purge AMIs that are NOT in the branch provided."`
 	Profile       string `short:"p" long:"profile" env:"PROFILE" required:"false" description:"The AWS profile to use."`
 	Region        string `short:"r" long:"region" env:"REGION" required:"false" description:"The AWS region to use."`
-	Lambda        bool   `long:"lambda" description:"Run as an AWS Lambda function." required:"false" env:"LAMBDA"`
+	Lambda        bool   `long:"lambda" required:"false" env:"LAMBDA" description:"Run as an AWS Lambda function."`
 }
 
 var options Options
@@ -37,7 +38,8 @@ func cleanImages() {
 	now := time.Now().UTC()
 	a := amiclean.AMIClean{
 		Branch:         options.Branch,
-		DryRun:         options.DryRun,
+		Delete:         options.Delete,
+		Invert:         options.Invert,
 		ExpirationDate: now.AddDate(0, 0, -int(options.RetentionDays)),
 		Logger:         logger,
 		EC2Client:      makeEC2Client(options.Region, options.Profile),

--- a/cmd/ami-cleaner/main.go
+++ b/cmd/ami-cleaner/main.go
@@ -17,7 +17,7 @@ import (
 type Options struct {
 	Delete        bool   `short:"D" long:"delete" description:"Actually purge AMIs (runs in dryrun mode by default)."`
 	RetentionDays int    `long:"days" default:"30" description:"Age of AMI in days before it is a candidate for removal."`
-	Branch        string `short:"b" long:"branch" required:"true" description:"Branch to purge. If the the --exclude option is used, this is the branch NOT to operate on."`
+	Branch        string `short:"b" long:"branch" required:"true" description:"Branch to purge. If the the --invert option is used, this is the branch NOT to operate on."`
 	Invert        bool   `short:"i" long:"invert" description:"Operate in inverted mode -- only purge AMIs that are NOT in the branch provided."`
 	Profile       string `short:"p" long:"profile" env:"PROFILE" required:"false" description:"The AWS profile to use."`
 	Region        string `short:"r" long:"region" env:"REGION" required:"false" description:"The AWS region to use."`

--- a/cmd/ami-cleaner/main.go
+++ b/cmd/ami-cleaner/main.go
@@ -1,146 +1,93 @@
 package main
 
 import (
-    "github.com/aws/aws-sdk-go/aws"
-    "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/trussworks/truss-aws-tools/internal/aws/session"
+	"github.com/trussworks/truss-aws-tools/amiclean"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	flag "github.com/jessevdk/go-flags"
+	"go.uber.org/zap"
 
-    "fmt"
-    "time"
-    //"errors"
+	"log"
+	"time"
 )
 
-const (
-	// RFC8601 is the date/time format used by AWS.
-	RFC8601 = "2006-01-02T15:04:05-07:00"
-)
-
-// This is the day beyond which we don't need to keep things (1 day ago)
-var ExpirationDate time.Time = time.Now().AddDate(0, 0, -1)
-
-// So, we need a function that can take a look at the images in some output
-// from DescribeImages and return us the images that match our conditions.
-func FindImagesToPurge(output *ec2.DescribeImagesOutput) []*ec2.Image {
-    var ImagesToPurge []*ec2.Image
-    for _, image := range output.Images {
-	    v := *image.CreationDate
-	    imageCreationTime, _ := time.Parse(RFC8601, v)
-	    for _, tag := range image.Tags {
-		    if *tag.Key == "Branch" && *tag.Value != "master" &&
-		    imageCreationTime.Before(ExpirationDate) {
-			    ImagesToPurge = append(ImagesToPurge, image)
-		    }
-	    }
-    }
-    return ImagesToPurge
+// The Options struct describes the command line options available.
+type Options struct {
+	DryRun bool `short:"n" long:"dryrun" description:"Run in dryrun mode
+	(ie, do not actually purge AMIs)."`
+	RetentionDays int `long:"days" default:"30" description:"Age of AMI in
+	days before it is a candidate for removal."`
+	Branch string `short:"b" long:"branch" description:"Branch to purge.
+	Preface with ! to purge all branches *but* this one (eg, !master would
+	purge all AMIs not from the master branch)."`
+	Profile string `short:"p" long:"profile" env:"PROFILE" required:"false"
+	description:"The AWS profile to use."`
+	Region string `short:"r" long:"region" env:"REGION" required:"false"
+	description:"The AWS region to use."`
 }
 
-// This function takes a slice of Images, and then finds the AMI IDs and
-// snapshot IDs associated with them.
-func GetIdsForProcessing(images []*ec2.Image) ([]string, []string) {
-	var amiIds, snapshotIds []string
-	for _, image := range images {
-		amiId := *image.ImageId
-		amiIds = append(amiIds, amiId)
-		for _, blockDevice := range image.BlockDeviceMappings {
-			snapshotId := *blockDevice.Ebs.SnapshotId
-			snapshotIds = append(snapshotIds, snapshotId)
-		}
+var options Options
+var logger *zap.Logger
+
+// This function is for establishing our session with AWS.
+func makeEC2Client(region, profile string) *ec2.EC2 {
+	sess := session.MustMakeSession(region, profile)
+	ec2Client := ec2.New(sess)
+	return ec2Client
+}
+
+func cleanImages() {
+	now := Time.Now().UTC()
+	a := amiclean.AMIClean{
+		Branch: options.Branch,
+		DryRun: options.DryRun,
+		ExpirationDate: now.AddDate(0, 0, -int(options.RetentionDays)),
+		Logger: logger,
+		EC2Client: makeEC2Client(options.Region, options.Profile),
 	}
-	return amiIds, snapshotIds
-}
 
-// This function takes a list of AMI IDs (as strings) and runs the deregister
-// operation on each one.
-func deregisterImageList(ec2conn *ec2.EC2, imageList []string) error {
-	for _, amiId := range imageList {
-		deregisterInput := &ec2.DeregisterImageInput{
-			DryRun: aws.Bool(true),
-			ImageId: aws.String(amiId),
-		}
-		fmt.Println("Attempting to deregister", amiId)
-		output, err := ec2conn.DeregisterImage(deregisterInput)
-		fmt.Println(output)
-		if err != nil {
-			fmt.Println(err)
-			// return err
-		}
+	availableImages, err := a.GetImages()
+	if err != nil {
+		logger.Fatal("unable to get list of available images",
+			zap.Error(err)
+		)
 	}
-	return nil
-}
 
-// This function takes a list of snapshot IDs (as strings) and runs the
-// delete operation on each one.
-func deleteSnapshotList(ec2conn *ec2.EC2, snapshotList []string) error {
-	for _, snapshotId := range snapshotList {
-		deleteInput := &ec2.DeleteSnapshotInput{
-			DryRun: aws.Bool(true),
-			SnapshotId: aws.String(snapshotId),
-		}
-		fmt.Println("Attempting to delete", snapshotId)
-		output, err := ec2conn.DeleteSnapshot(deleteInput)
-		fmt.Println(output)
-		if err != nil {
-			fmt.Println(err)
-			// return err
-		}
+	purgeList := a.FindImagesToPurge(availableImages)
+
+	amiIdsToPurge, snapshotIdsToPurge := a.GetIdsToProcess(purgeList)
+
+	err = a.DeregisterImageList(amiIdsToPurge)
+	if err != nil {
+		logger.Fatal("unable to deregister AMIs",
+			zap.Error(err)
+		)
 	}
-	return nil
-}
 
+	err = a.DeleteSnapshotList(snapshotIdsToPurge)
+	if err != nil {
+		logger.Fatal("unable to delete snapshots",
+			zap.Error(err)
+		)
+	}
+
+}
 
 func main() {
-    // This creates "sess", which is essentially a collection of credentials,
-    // a region, etc needed for establishing a connection to an AWS endpoint.
-    sess := session.Must(session.NewSessionWithOptions(session.Options{
-	SharedConfigState: session.SharedConfigEnable,
-    }))
+	// First, parse out our command line options:
+	parser := flag.NewParser(&options, flag.Default)
+	_, err := parser.Parse()
+	if err != nil {
+		log.Fatal(err)
+	}
 
-    // Now we're going to create a new connection to EC2 named "ec2Svc" that
-    // uses the credentials and info we passed from sess above.
-    ec2Svc := ec2.New(sess)
+	// Initialize the zap logger:
+	logger, err = zap.NewProduction()
+	if err != nil {
+		log.Fatalf("can't initialize zap logger: %v", err)
+	}
 
-    // So now we reach the real conundrum. DescribeImages does not let us
-    // filter out images that *don't* match a certain tag (everything not
-    // off the master branch, for instance) and it doesn't let us get them
-    // by age either.
-
-    // So what can we do to reduce the number of things we have to look at?
-    // Well, we can toss out anything public at least, so that should get us
-    // only the AMIs we're generating.
-    input := &ec2.DescribeImagesInput{
-        Filters: []*ec2.Filter{
-            {
-                Name: aws.String("is-public"),
-		Values : []*string{aws.String("false")},
-	    },
-	},
-    }
-
-    // Now we grab everything the matches the conditions above. This is an
-    // EC2DescribeImagesOutput type, which consists of a slice of Image
-    // types.
-    result, err := ec2Svc.DescribeImages(input)
-
-    if err != nil {
-        fmt.Println(err.Error())
-	return
-    }
-
-    // Now we have the list of images; let's put them through the filter
-    // and get the ones that meet our conditions.
-    purgelist := FindImagesToPurge(result)
-
-    // Now we have a list of images to purge; we need two things from each
-    // image; the ImageId and any BlockDeviceMappings.Ebs.SnapshotId elements
-    // (they need to be deleted after we deregister the AMI).
-    amiIds, snapshotIds := GetIdsForProcessing(purgelist)
-
-    // Now we have a list of AMIs and snapshots to get deleted; we need to
-    // deregister AMIs first, then delete the snapshots.
-    deregisterImageList(ec2Svc, amiIds)
-
-    // And now that the AMIs have been registered, we can delete the snapshots.
-    deleteSnapshotList(ec2Svc, snapshotIds)
+	// And now we just call cleanImages to actually do the work.
+	cleanImages()
 
 }

--- a/cmd/ami-cleaner/main.go
+++ b/cmd/ami-cleaner/main.go
@@ -55,18 +55,9 @@ func cleanImages() {
 
 	purgeList := a.FindImagesToPurge(availableImages)
 
-	amiIdsToPurge, snapshotIdsToPurge := a.GetIdsToProcess(purgeList)
-
-	err = a.DeregisterImageList(amiIdsToPurge)
+	err = a.PurgeImages(purgeList)
 	if err != nil {
-		logger.Fatal("unable to deregister AMIs",
-			zap.Error(err)
-		)
-	}
-
-	err = a.DeleteSnapshotList(snapshotIdsToPurge)
-	if err != nil {
-		logger.Fatal("unable to delete snapshots",
+		logger.Fatal("unable to complete image purge",
 			zap.Error(err)
 		)
 	}

--- a/cmd/ami-cleaner/main.go
+++ b/cmd/ami-cleaner/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"github.com/trussworks/truss-aws-tools/internal/aws/session"
-	"github.com/trussworks/truss-aws-tools/amiclean"
+	"github.com/trussworks/truss-aws-tools/pkg/amiclean"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	flag "github.com/jessevdk/go-flags"
 	"go.uber.org/zap"
@@ -13,17 +13,11 @@ import (
 
 // The Options struct describes the command line options available.
 type Options struct {
-	DryRun bool `short:"n" long:"dryrun" description:"Run in dryrun mode
-	(ie, do not actually purge AMIs)."`
-	RetentionDays int `long:"days" default:"30" description:"Age of AMI in
-	days before it is a candidate for removal."`
-	Branch string `short:"b" long:"branch" description:"Branch to purge.
-	Preface with ! to purge all branches *but* this one (eg, !master would
-	purge all AMIs not from the master branch)."`
-	Profile string `short:"p" long:"profile" env:"PROFILE" required:"false"
-	description:"The AWS profile to use."`
-	Region string `short:"r" long:"region" env:"REGION" required:"false"
-	description:"The AWS region to use."`
+	DryRun bool `short:"n" long:"dryrun" description:"Run in dryrun mode (ie, do not actually purge AMIs)."`
+	RetentionDays int `long:"days" default:"30" description:"Age of AMI in days before it is a candidate for removal."`
+	Branch string `short:"b" long:"branch" description:"Branch to purge.  Preface with ! to purge all branches *but* this one (eg, !master would purge all AMIs not from the master branch)."`
+	Profile string `short:"p" long:"profile" env:"PROFILE" required:"false" description:"The AWS profile to use."`
+	Region string `short:"r" long:"region" env:"REGION" required:"false" description:"The AWS region to use."`
 }
 
 var options Options
@@ -37,7 +31,7 @@ func makeEC2Client(region, profile string) *ec2.EC2 {
 }
 
 func cleanImages() {
-	now := Time.Now().UTC()
+	now := time.Now().UTC()
 	a := amiclean.AMIClean{
 		Branch: options.Branch,
 		DryRun: options.DryRun,
@@ -49,7 +43,7 @@ func cleanImages() {
 	availableImages, err := a.GetImages()
 	if err != nil {
 		logger.Fatal("unable to get list of available images",
-			zap.Error(err)
+			zap.Error(err),
 		)
 	}
 
@@ -58,7 +52,7 @@ func cleanImages() {
 	err = a.PurgeImages(purgeList)
 	if err != nil {
 		logger.Fatal("unable to complete image purge",
-			zap.Error(err)
+			zap.Error(err),
 		)
 	}
 

--- a/cmd/ami-cleaner/main.go
+++ b/cmd/ami-cleaner/main.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+    "github.com/aws/aws-sdk-go/aws"
+    "github.com/aws/aws-sdk-go/aws/session"
+    "github.com/aws/aws-sdk-go/service/ec2"
+
+    "fmt"
+    "time"
+)
+
+const (
+	// RFC8601 is the date/time format used by AWS.
+	RFC8601 = "2006-01-02T15:04:05-07:00"
+)
+
+// This is the day beyond which we don't need to keep things (1 day ago)
+var ExpirationDate time.Time = time.Now().AddDate(0, 0, -1)
+
+// So, we need a function that can take a look at the images in some output
+// from DescribeImages and return us the images that match our conditions.
+func FindImagesToPurge(output *ec2.DescribeImagesOutput) []*ec2.Image {
+    var ImagesToPurge []*ec2.Image
+    for _, image := range output.Images {
+	    v := *image.CreationDate
+	    imageCreationTime, _ := time.Parse(RFC8601, v)
+	    for _, tag := range image.Tags {
+		    if *tag.Key == "Branch" && *tag.Value != "master" &&
+		    imageCreationTime.Before(ExpirationDate) {
+			    ImagesToPurge = append(ImagesToPurge, image)
+		    }
+	    }
+    }
+    return ImagesToPurge
+}
+
+func GetIdsForProcessing(images []*ec2.Image) ([]string, []string) {
+	var amiIds, snapshotIds []string
+	for _, image := range images {
+		amiId := *image.ImageId
+		amiIds = append(amiIds, amiId)
+		for _, blockDevice := range image.BlockDeviceMappings {
+			snapshotId := *blockDevice.Ebs.SnapshotId
+			snapshotIds = append(snapshotIds, snapshotId)
+		}
+	}
+	return amiIds, snapshotIds
+}
+
+func main() {
+    // This creates "sess", which is essentially a collection of credentials,
+    // a region, etc needed for establishing a connection to an AWS endpoint.
+    sess := session.Must(session.NewSessionWithOptions(session.Options{
+	SharedConfigState: session.SharedConfigEnable,
+    }))
+
+    // Now we're going to create a new connection to EC2 named "ec2Svc" that
+    // uses the credentials and info we passed from sess above.
+    ec2Svc := ec2.New(sess)
+
+    // So now we reach the real conundrum. DescribeImages does not let us
+    // filter out images that *don't* match a certain tag (everything not
+    // off the master branch, for instance) and it doesn't let us get them
+    // by age either.
+
+    // So what can we do to reduce the number of things we have to look at?
+    // Well, we can toss out anything public at least, so that should get us
+    // only the AMIs we're generating.
+    input := &ec2.DescribeImagesInput{
+        Filters: []*ec2.Filter{
+            {
+                Name: aws.String("is-public"),
+		Values : []*string{aws.String("false")},
+	    },
+	},
+    }
+
+    // Now we grab everything the matches the conditions above. This is an
+    // EC2DescribeImagesOutput type, which consists of a slice of Image
+    // types.
+    result, err := ec2Svc.DescribeImages(input)
+
+    if err != nil {
+        fmt.Println(err.Error())
+	return
+    }
+
+    // Now we have the list of images; let's put them through the filter
+    // and get the ones that meet our conditions.
+    purgelist := FindImagesToPurge(result)
+
+    // Now we have a list of images to purge; we need two things from each
+    // image; the ImageId and any BlockDeviceMappings.Ebs.SnapshotId elements
+    // (they need to be deleted after we deregister the AMI).
+    amiIds, snapshotIds := GetIdsForProcessing(purgelist)
+
+    fmt.Println(amiIds)
+    fmt.Println(snapshotIds)
+}

--- a/cmd/ami-cleaner/main.go
+++ b/cmd/ami-cleaner/main.go
@@ -15,12 +15,12 @@ import (
 
 // The Options struct describes the command line options available.
 type Options struct {
-	DryRun bool `short:"n" long:"dryrun" description:"Run in dryrun mode (ie, do not actually purge AMIs)."`
-	RetentionDays int `long:"days" default:"30" description:"Age of AMI in days before it is a candidate for removal."`
-	Branch string `short:"b" long:"branch" description:"Branch to purge.  Preface with ! to purge all branches *but* this one (eg, !master would purge all AMIs not from the master branch)."`
-	Profile string `short:"p" long:"profile" env:"PROFILE" required:"false" description:"The AWS profile to use."`
-	Region string `short:"r" long:"region" env:"REGION" required:"false" description:"The AWS region to use."`
-	Lambda bool `long:"lambda" description:"Run as an AWS Lambda function." required:"false" env:"LAMBDA"`
+	DryRun        bool   `short:"n" long:"dryrun" description:"Run in dryrun mode (ie, do not actually purge AMIs)."`
+	RetentionDays int    `long:"days" default:"30" description:"Age of AMI in days before it is a candidate for removal."`
+	Branch        string `short:"b" long:"branch" description:"Branch to purge.  Preface with ! to purge all branches *but* this one (eg, !master would purge all AMIs not from the master branch)."`
+	Profile       string `short:"p" long:"profile" env:"PROFILE" required:"false" description:"The AWS profile to use."`
+	Region        string `short:"r" long:"region" env:"REGION" required:"false" description:"The AWS region to use."`
+	Lambda        bool   `long:"lambda" description:"Run as an AWS Lambda function." required:"false" env:"LAMBDA"`
 }
 
 var options Options
@@ -36,11 +36,11 @@ func makeEC2Client(region, profile string) *ec2.EC2 {
 func cleanImages() {
 	now := time.Now().UTC()
 	a := amiclean.AMIClean{
-		Branch: options.Branch,
-		DryRun: options.DryRun,
+		Branch:         options.Branch,
+		DryRun:         options.DryRun,
 		ExpirationDate: now.AddDate(0, 0, -int(options.RetentionDays)),
-		Logger: logger,
-		EC2Client: makeEC2Client(options.Region, options.Profile),
+		Logger:         logger,
+		EC2Client:      makeEC2Client(options.Region, options.Profile),
 	}
 
 	availableImages, err := a.GetImages()

--- a/pkg/amiclean/ami-cleaner.go
+++ b/pkg/amiclean/ami-cleaner.go
@@ -1,0 +1,167 @@
+package amiclean
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws/aws-sdk-go/aws"
+	"go.uber.org/zap"
+
+	"strings"
+	"time"
+)
+
+const (
+	// RFC8601 is the date/time format used by AWS.
+	RFC8601 = "2006-01-02T15:04:05-07:00"
+)
+
+// AMIClean defines parameters for cleaning up AMIs based on the Branch and
+// Expiration Date.
+type AMIClean struct {
+	Branch         string
+	DryRun         bool
+	ExpirationDate time.Time
+	Logger         *zap.Logger
+	EC2Client      *ec2.EC2
+}
+
+// GetImages gets us all the private AMIs on our account so that they can be
+// looked through later. We have to do this here because the AWS API does not
+// allow you to search for AMIs by creation date or by *not* having a tag set to
+// a certain value, which would speed this up considerably.
+func (a *AMIClean) GetImages() (*ec2.DescribeImagesOutput, error) {
+	var output *ec2.DescribeImagesOutput
+
+	input := &ec2.DescribeImagesInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("is-public"),
+				Values: []*string{aws.String("false")},
+			},
+		},
+	}
+
+	output, err := a.EC2Client.DescribeImages(input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return output, err
+}
+
+// FindImagesToPurge looks through the AMIs available and produces a slice of
+// ec2.Image objects to put on the chopping block based on the contents of the
+// AMIClean struct.
+func (a *AMIClean) FindImagesToPurge(output *ec2.DescribeImagesOutput) []*ec2.Image {
+	var ImagesToPurge []*ec2.Image
+	for _, image := range output.Images {
+		ct := *image.CreationDate
+		imageCreationTime, _ := time.Parse(RFC8601, ct)
+		if imageCreationTime.After(ExpirationDate) {
+			continue
+		} else {
+			if strings.Prefix(a.Branch, "!") {
+				branchname := a.Branch[1:]
+				for _, tag := range image.Tags {
+					if *tag.Key == "Branch" && *tag.Value != branchname {
+						a.Logger.Info("selected ami for
+						purging",
+							zap.String("ami-id",
+							image.ImageId),
+							zap.String("ami-branch-tag",
+							branchname),
+							zap.String("ami-creation-date",
+							imageCreationTime),
+						)
+						ImagesToPurge =
+							append(ImagesToPurge, image)
+					}
+				}
+			} else {
+				for _, tag := range image.Tags {
+					if *tag.Key == "Branch" && *tag.Value == a.Branch {
+						a.Logger.Info("selected ami for
+						purging",
+							zap.String("ami-id",
+							image.ImageId),
+							zap.String("ami-branch-tag",
+							a.Branch),
+							zap.String("ami-creation-date",
+							imageCreationTime),
+						)
+						ImagesToPurge =
+							append(ImagesToPurge, image)
+					}
+				}
+			}
+		}
+	}
+	return ImagesToPurge
+}
+
+// GetIdsToProcess takes a slice of ec2.Image objects and pulls out the AMI IDs
+// and snapshot IDs so that we can get rid of them later.
+func (a *AMIClean) GetIdsToProcess(images []*ec2.Image) ([]string, []string) {
+	var amiIds, snapshotIds []string
+	for _, image := images {
+		amiId := *image.ImageId
+		amiIds = append(amiIds, amiId)
+		for _, blockDevice := range image.BlockDeviceMappings {
+			snapshotId := *blockDevice.Ebs.SnapshotId
+			snapshotIds = append(snapshotIds, snapshotId)
+		}
+	}
+	return amiIds, snapshotIds
+}
+
+// DeregisterImageList takes a slice of AMI IDs (as strings) and runs the
+// deregister operation on each one. This effectively "deletes" the AMI from
+// AWS, but we also have to clean up the snapshots.
+func (a *AMIClean) DeregisterImageList(imageList []string) error {
+	for _, amiId := range imageList {
+		deregisterInput := &ec2.DeregisterImageInput{
+			DryRun: aws.Bool(a.DryRun),
+			ImageId: aws.String(amiId),
+		}
+		if a.DryRun {
+			a.Logger.Info("would deregister ami",
+				zap.String("ami-id", amiId)
+			)
+		} else {
+			a.Logger.Info("deregistering ami",
+				zap.String("ami-id", amiId)
+			)
+			output, err := a.EC2Client.DeregisterImage(deregisterInput)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// DeleteSnapshotList works mostly the same as DeregisterImageList, only it is
+// deleting the snapshots that were linked to the AMIs, taking care of the last
+// step to remove these AMIs.
+func (a *AMIClean) DeleteSnapshotList(snapshotList []string) error {
+	for _, snapshotId := range snapshotList {
+		deleteInput := &ec2.DeleteSnapshotInput{
+			DryRun: aws.Bool(a.DryRun),
+			SnapshotId: aws.String(snapshotId),
+		}
+		if a.DryRun {
+			a.Logger.Info("would delete snapshot",
+				zap.String("snapshot-id", snapshotId)
+			)
+		} else {
+			a.Logger.Info("deleting snapshot",
+				zap.String("snapshot-id", snapshotId)
+			)
+			output, err := a.EC2Client.DeleteSnapshot(deleteInput)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/amiclean/ami_cleaner.go
+++ b/pkg/amiclean/ami_cleaner.go
@@ -46,7 +46,7 @@ func (a *AMIClean) GetImages() (*ec2.DescribeImagesOutput, error) {
 		return nil, err
 	}
 
-	return output, err
+	return output, nil
 }
 
 // TODO: Need a generic function that will find the value of a given tag key

--- a/pkg/amiclean/ami_cleaner.go
+++ b/pkg/amiclean/ami_cleaner.go
@@ -49,6 +49,12 @@ func (a *AMIClean) GetImages() (*ec2.DescribeImagesOutput, error) {
 	return output, err
 }
 
+// TODO: Need a generic function that will find the value of a given tag key
+// for an AMI. This will simplify the code for FindImagesToPurge and also
+// make it easier to give the tag output in the PurgeImages function. Making
+// it generic will also allow us to change the branch option to a more generic
+// tag option.
+
 // FindImagesToPurge looks through the AMIs available and produces a slice of
 // ec2.Image objects to put on the chopping block based on the contents of the
 // AMIClean struct.
@@ -56,12 +62,19 @@ func (a *AMIClean) FindImagesToPurge(output *ec2.DescribeImagesOutput) []*ec2.Im
 	var ImagesToPurge []*ec2.Image
 	for _, image := range output.Images {
 		imageCreationTime, _ := time.Parse(RFC8601, *image.CreationDate)
+		// If the AMI isn't old enough to be purged, we don't care
+		// about anything else. Just move on.
 		if imageCreationTime.After(a.ExpirationDate) {
 			continue
 		} else {
+			// If invert is set, we're looking for AMIs which are
+			// NOT in the branch selected.
 			if a.Invert {
 				for _, tag := range image.Tags {
 					if *tag.Key == "Branch" && *tag.Value != a.Branch {
+						// Optimally, this output
+						// should all get moved into the
+						// PurgeImages call.
 						a.Logger.Info("selected ami for purging",
 							zap.String("ami-id",
 								*image.ImageId),
@@ -74,9 +87,12 @@ func (a *AMIClean) FindImagesToPurge(output *ec2.DescribeImagesOutput) []*ec2.Im
 							append(ImagesToPurge, image)
 					}
 				}
+				// Otherwise, we're looking at all the AMIs with Branch
+				// set to whatever we set it to in the command line.
 			} else {
 				for _, tag := range image.Tags {
 					if *tag.Key == "Branch" && *tag.Value == a.Branch {
+						// Same note as above.
 						a.Logger.Info("selected ami for purging",
 							zap.String("ami-id",
 								*image.ImageId),
@@ -101,47 +117,57 @@ func (a *AMIClean) FindImagesToPurge(output *ec2.DescribeImagesOutput) []*ec2.Im
 // orphaned snapshots lying around.
 func (a *AMIClean) PurgeImages(images []*ec2.Image) error {
 	for _, image := range images {
-		// There may be multiple snapshots attached to a single AMI,
-		// so we need to build a list and iterate on them.
-		var snapshotIds []*string
-		for _, blockDevice := range image.BlockDeviceMappings {
-			snapshotID := *blockDevice.Ebs.SnapshotId
-			snapshotIds = append(snapshotIds, &snapshotID)
-		}
-		deregisterInput := &ec2.DeregisterImageInput{
-			DryRun:  aws.Bool(!a.Delete),
-			ImageId: aws.String(*image.ImageId),
-		}
-		if a.Delete {
-			a.Logger.Info("deregistering ami",
+		// This is a circuit breaker because we currently assume all
+		// AMIs have EBS volumes. This is the case right now, but it
+		// isn't true in a more general case. More functionality would
+		// need to be added to handle instance-store backed AMIs.
+		if *image.RootDeviceType != "ebs" {
+			a.Logger.Info("image root device not EBS; will not purge",
 				zap.String("ami-id", *image.ImageId),
 			)
-			_, err := a.EC2Client.DeregisterImage(deregisterInput)
-			if err != nil {
-				return err
-			}
 		} else {
-			a.Logger.Info("would deregister ami",
-				zap.String("ami-id", *image.ImageId),
-			)
-		}
-		for _, snapshot := range snapshotIds {
-			deleteInput := &ec2.DeleteSnapshotInput{
-				DryRun:     aws.Bool(!a.Delete),
-				SnapshotId: aws.String(*snapshot),
+			// There may be multiple snapshots attached to a single AMI,
+			// so we need to build a list and iterate on them.
+			var snapshotIds []*string
+			for _, blockDevice := range image.BlockDeviceMappings {
+				snapshotID := *blockDevice.Ebs.SnapshotId
+				snapshotIds = append(snapshotIds, &snapshotID)
+			}
+			deregisterInput := &ec2.DeregisterImageInput{
+				DryRun:  aws.Bool(!a.Delete),
+				ImageId: aws.String(*image.ImageId),
 			}
 			if a.Delete {
-				a.Logger.Info("deleting snapshot",
-					zap.String("snapshot-id", *deleteInput.SnapshotId),
+				a.Logger.Info("deregistering ami",
+					zap.String("ami-id", *image.ImageId),
 				)
-				_, err := a.EC2Client.DeleteSnapshot(deleteInput)
+				_, err := a.EC2Client.DeregisterImage(deregisterInput)
 				if err != nil {
 					return err
 				}
 			} else {
-				a.Logger.Info("would delete snapshot",
-					zap.String("snapshot-id", *deleteInput.SnapshotId),
+				a.Logger.Info("would deregister ami",
+					zap.String("ami-id", *image.ImageId),
 				)
+			}
+			for _, snapshot := range snapshotIds {
+				deleteInput := &ec2.DeleteSnapshotInput{
+					DryRun:     aws.Bool(!a.Delete),
+					SnapshotId: aws.String(*snapshot),
+				}
+				if a.Delete {
+					a.Logger.Info("deleting snapshot",
+						zap.String("snapshot-id", *deleteInput.SnapshotId),
+					)
+					_, err := a.EC2Client.DeleteSnapshot(deleteInput)
+					if err != nil {
+						return err
+					}
+				} else {
+					a.Logger.Info("would delete snapshot",
+						zap.String("snapshot-id", *deleteInput.SnapshotId),
+					)
+				}
 			}
 		}
 	}

--- a/pkg/amiclean/ami_cleaner.go
+++ b/pkg/amiclean/ami_cleaner.go
@@ -1,8 +1,8 @@
 package amiclean
 
 import (
-	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"go.uber.org/zap"
 
 	"strings"
@@ -68,11 +68,11 @@ func (a *AMIClean) FindImagesToPurge(output *ec2.DescribeImagesOutput) []*ec2.Im
 					if *tag.Key == "Branch" && *tag.Value != branchname {
 						a.Logger.Info("selected ami for purging",
 							zap.String("ami-id",
-							*image.ImageId),
+								*image.ImageId),
 							zap.String("ami-branch-tag",
-							*tag.Value),
+								*tag.Value),
 							zap.String("ami-creation-date",
-							imageCreationTime.String()),
+								imageCreationTime.String()),
 						)
 						ImagesToPurge =
 							append(ImagesToPurge, image)
@@ -84,11 +84,11 @@ func (a *AMIClean) FindImagesToPurge(output *ec2.DescribeImagesOutput) []*ec2.Im
 					if *tag.Key == "Branch" && *tag.Value == a.Branch {
 						a.Logger.Info("selected ami for purging",
 							zap.String("ami-id",
-							*image.ImageId),
+								*image.ImageId),
 							zap.String("ami-branch-tag",
-							*tag.Value),
+								*tag.Value),
 							zap.String("ami-creation-date",
-							imageCreationTime.String()),
+								imageCreationTime.String()),
 						)
 						ImagesToPurge =
 							append(ImagesToPurge, image)
@@ -114,7 +114,7 @@ func (a *AMIClean) PurgeImages(images []*ec2.Image) error {
 			snapshotIds = append(snapshotIds, &snapshotId)
 		}
 		deregisterInput := &ec2.DeregisterImageInput{
-			DryRun: aws.Bool(a.DryRun),
+			DryRun:  aws.Bool(a.DryRun),
 			ImageId: aws.String(*image.ImageId),
 		}
 		if a.DryRun {
@@ -132,7 +132,7 @@ func (a *AMIClean) PurgeImages(images []*ec2.Image) error {
 		}
 		for _, snapshot := range snapshotIds {
 			deleteInput := &ec2.DeleteSnapshotInput{
-				DryRun: aws.Bool(a.DryRun),
+				DryRun:     aws.Bool(a.DryRun),
 				SnapshotId: aws.String(*snapshot),
 			}
 			if a.DryRun {

--- a/pkg/amiclean/ami_cleaner.go
+++ b/pkg/amiclean/ami_cleaner.go
@@ -110,8 +110,8 @@ func (a *AMIClean) PurgeImages(images []*ec2.Image) error {
 		// so we need to build a list and iterate on them.
 		var snapshotIds []*string
 		for _, blockDevice := range image.BlockDeviceMappings {
-			snapshotId := *blockDevice.Ebs.SnapshotId
-			snapshotIds = append(snapshotIds, &snapshotId)
+			snapshotID := *blockDevice.Ebs.SnapshotId
+			snapshotIds = append(snapshotIds, &snapshotID)
 		}
 		deregisterInput := &ec2.DeregisterImageInput{
 			DryRun:  aws.Bool(a.DryRun),

--- a/pkg/amiclean/ami_cleaner_test.go
+++ b/pkg/amiclean/ami_cleaner_test.go
@@ -17,7 +17,10 @@ import (
 //   - one must have multiple EBS volumes
 
 var newMasterImage = &ec2.Image{
+	Description:
 	ImageId: "ami-11111111111111111"
+	CreationDate:
+	Tags:
 }
 
 var newishDevImage = &ec2.Image{

--- a/pkg/amiclean/ami_cleaner_test.go
+++ b/pkg/amiclean/ami_cleaner_test.go
@@ -92,7 +92,7 @@ func TestFindImagesToPurge(t *testing.T) {
 	for _, table := range tables {
 		a := AMIClean{
 			Branch:         table.Branch,
-			Invert:         table.Exclude,
+			Invert:         table.Invert,
 			Delete:         false,
 			ExpirationDate: now.AddDate(0, 0, -int(table.RetentionDays)),
 			Logger:         logger,

--- a/pkg/amiclean/ami_cleaner_test.go
+++ b/pkg/amiclean/ami_cleaner_test.go
@@ -3,39 +3,108 @@ package amiclean
 import (
 	"testing"
 	"time"
+	"reflect"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"go.uber.org/zap"
 )
 
-// Dummy data:
-//   - new AMI in master branch
-//   - new-ish AMI in development branch
-//   - old AMI in development branch
-//   - one must have multiple tags
-//   - one must have multiple EBS volumes
-
 var newMasterImage = &ec2.Image{
-	Description:
-	ImageId: "ami-11111111111111111"
-	CreationDate:
-	Tags:
+	Description: aws.String("New Master Image"),
+	ImageId: aws.String("ami-11111111111111111"),
+	CreationDate: aws.String("2019-03-31T21:04:57.000Z"),
+	Tags: []*ec2.Tag{
+		&ec2.Tag{ Key: aws.String("Branch"), Value: aws.String("master") },
+		&ec2.Tag{ Key: aws.String("Name"), Value: aws.String("newMasterImage") },
+	},
+	BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+		&ec2.BlockDeviceMapping{
+			DeviceName: aws.String("/dev/xvda"),
+			Ebs: &ec2.EbsBlockDevice{
+				SnapshotId: aws.String("snap-11111111111111111"),
+			},
+		},
+	},
 }
 
 var newishDevImage = &ec2.Image{
-	ImageId: "ami-22222222222222222"
+	Description: aws.String("Newish Dev Image"),
+	ImageId: aws.String("ami-22222222222222222"),
+	CreationDate: aws.String("2019-03-30T21:04:57.000Z"),
+	Tags: []*ec2.Tag{
+		&ec2.Tag{ Key: aws.String("Branch"), Value: aws.String("development") },
+		&ec2.Tag{ Key: aws.String("Name"), Value: aws.String("newishDevImage") },
+	},
+	BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+		&ec2.BlockDeviceMapping{
+			DeviceName: aws.String("/dev/xvda"),
+			Ebs: &ec2.EbsBlockDevice{
+				SnapshotId: aws.String("snap-22222222222222222"),
+			},
+		},
+		&ec2.BlockDeviceMapping{
+			DeviceName: aws.String("/dev/xvdb"),
+			Ebs: &ec2.EbsBlockDevice{
+				SnapshotId: aws.String("snap-22222222222222223"),
+			},
+		},
+	},
 }
 
 var oldDevImage = &ec2.Image{
-	ImageId: "ami-33333333333333333"
+	Description: aws.String("Old Dev Image"),
+	ImageId: aws.String("ami-33333333333333333"),
+	CreationDate: aws.String("2019-03-01T21:04:57.000Z"),
+	Tags: []*ec2.Tag{
+		&ec2.Tag{ Key: aws.String("Name"), Value: aws.String("oldDevImage") },
+		&ec2.Tag{ Key: aws.String("Branch"), Value: aws.String("development") },
+	},
+	BlockDeviceMappings: []*ec2.BlockDeviceMapping{
+		&ec2.BlockDeviceMapping{
+			DeviceName: aws.String("/dev/xvda"),
+			Ebs: &ec2.EbsBlockDevice{
+				SnapshotId: aws.String("snap-33333333333333333"),
+			},
+		},
+	},
 }
 
-// Need to test FindImagesToPurge with:
-// Branch: master, retention 30 days
-// Branch: development, retention 30 days
-// Branch: development, retention 1 day
-// Branch: !master, retention 1 day
+var testImages = []*ec2.Image{ newMasterImage, newishDevImage, oldDevImage }
 
-// Need to test GetIdsToProcess against dummy data and generate proper list of
-// AMI IDs and Snapshot IDs
+var now = time.Date(2019, 4, 1, 0, 0, 0, 0, time.UTC)
+
+func TestFindImagesToPurge(t *testing.T) {
+	logger, _ := zap.NewProduction()
+	tables := []struct {
+		imageSet []*ec2.Image
+		Branch string
+		RetentionDays int
+		resultSet []*ec2.Image
+	}{
+		{ testImages, "master", 1, []*ec2.Image{} },
+		{ testImages, "development", 30, []*ec2.Image{ oldDevImage } },
+		{ testImages, "development", 1, []*ec2.Image{ newishDevImage, oldDevImage } },
+		{ testImages, "!master", 1, []*ec2.Image{ newishDevImage, oldDevImage } },
+	}
+
+	for _, table := range tables {
+		a := AMIClean{
+			Branch: table.Branch,
+			DryRun: true,
+			ExpirationDate: now.AddDate(0, 0, -int(table.RetentionDays)),
+			Logger: logger,
+			EC2Client: nil,
+		}
+
+		output := &ec2.DescribeImagesOutput{ Images: testImages }
+		result := a.FindImagesToPurge(output)
+		if !reflect.DeepEqual(result, table.resultSet) {
+			t.Errorf("ERROR: branch %v, retention %d days failed;\n\texpected: %v\n\tgot: %v",
+			table.Branch,
+			table.RetentionDays,
+			table.resultSet,
+			result)
+		}
+	}
+}

--- a/pkg/amiclean/ami_cleaner_test.go
+++ b/pkg/amiclean/ami_cleaner_test.go
@@ -79,19 +79,21 @@ func TestFindImagesToPurge(t *testing.T) {
 	tables := []struct {
 		imageSet      []*ec2.Image
 		Branch        string
+		Invert        bool
 		RetentionDays int
 		resultSet     []*ec2.Image
 	}{
-		{testImages, "master", 1, []*ec2.Image(nil)},
-		{testImages, "development", 30, []*ec2.Image{oldDevImage}},
-		{testImages, "development", 1, []*ec2.Image{newishDevImage, oldDevImage}},
-		{testImages, "!master", 1, []*ec2.Image{newishDevImage, oldDevImage}},
+		{testImages, "master", false, 1, []*ec2.Image(nil)},
+		{testImages, "development", false, 30, []*ec2.Image{oldDevImage}},
+		{testImages, "development", false, 1, []*ec2.Image{newishDevImage, oldDevImage}},
+		{testImages, "master", true, 1, []*ec2.Image{newishDevImage, oldDevImage}},
 	}
 
 	for _, table := range tables {
 		a := AMIClean{
 			Branch:         table.Branch,
-			DryRun:         true,
+			Invert:         table.Exclude,
+			Delete:         false,
 			ExpirationDate: now.AddDate(0, 0, -int(table.RetentionDays)),
 			Logger:         logger,
 			EC2Client:      nil,

--- a/pkg/amiclean/ami_cleaner_test.go
+++ b/pkg/amiclean/ami_cleaner_test.go
@@ -1,0 +1,38 @@
+package amiclean
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"go.uber.org/zap"
+)
+
+// Dummy data:
+//   - new AMI in master branch
+//   - new-ish AMI in development branch
+//   - old AMI in development branch
+//   - one must have multiple tags
+//   - one must have multiple EBS volumes
+
+var newMasterImage = &ec2.Image{
+	ImageId: "ami-11111111111111111"
+}
+
+var newishDevImage = &ec2.Image{
+	ImageId: "ami-22222222222222222"
+}
+
+var oldDevImage = &ec2.Image{
+	ImageId: "ami-33333333333333333"
+}
+
+// Need to test FindImagesToPurge with:
+// Branch: master, retention 30 days
+// Branch: development, retention 30 days
+// Branch: development, retention 1 day
+// Branch: !master, retention 1 day
+
+// Need to test GetIdsToProcess against dummy data and generate proper list of
+// AMI IDs and Snapshot IDs

--- a/pkg/amiclean/ami_cleaner_test.go
+++ b/pkg/amiclean/ami_cleaner_test.go
@@ -1,9 +1,9 @@
 package amiclean
 
 import (
+	"reflect"
 	"testing"
 	"time"
-	"reflect"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -11,12 +11,12 @@ import (
 )
 
 var newMasterImage = &ec2.Image{
-	Description: aws.String("New Master Image"),
-	ImageId: aws.String("ami-11111111111111111"),
+	Description:  aws.String("New Master Image"),
+	ImageId:      aws.String("ami-11111111111111111"),
 	CreationDate: aws.String("2019-03-31T21:04:57.000Z"),
 	Tags: []*ec2.Tag{
-		&ec2.Tag{ Key: aws.String("Branch"), Value: aws.String("master") },
-		&ec2.Tag{ Key: aws.String("Name"), Value: aws.String("newMasterImage") },
+		&ec2.Tag{Key: aws.String("Branch"), Value: aws.String("master")},
+		&ec2.Tag{Key: aws.String("Name"), Value: aws.String("newMasterImage")},
 	},
 	BlockDeviceMappings: []*ec2.BlockDeviceMapping{
 		&ec2.BlockDeviceMapping{
@@ -29,12 +29,12 @@ var newMasterImage = &ec2.Image{
 }
 
 var newishDevImage = &ec2.Image{
-	Description: aws.String("Newish Dev Image"),
-	ImageId: aws.String("ami-22222222222222222"),
+	Description:  aws.String("Newish Dev Image"),
+	ImageId:      aws.String("ami-22222222222222222"),
 	CreationDate: aws.String("2019-03-30T21:04:57.000Z"),
 	Tags: []*ec2.Tag{
-		&ec2.Tag{ Key: aws.String("Branch"), Value: aws.String("development") },
-		&ec2.Tag{ Key: aws.String("Name"), Value: aws.String("newishDevImage") },
+		&ec2.Tag{Key: aws.String("Branch"), Value: aws.String("development")},
+		&ec2.Tag{Key: aws.String("Name"), Value: aws.String("newishDevImage")},
 	},
 	BlockDeviceMappings: []*ec2.BlockDeviceMapping{
 		&ec2.BlockDeviceMapping{
@@ -53,12 +53,12 @@ var newishDevImage = &ec2.Image{
 }
 
 var oldDevImage = &ec2.Image{
-	Description: aws.String("Old Dev Image"),
-	ImageId: aws.String("ami-33333333333333333"),
+	Description:  aws.String("Old Dev Image"),
+	ImageId:      aws.String("ami-33333333333333333"),
 	CreationDate: aws.String("2019-03-01T21:04:57.000Z"),
 	Tags: []*ec2.Tag{
-		&ec2.Tag{ Key: aws.String("Name"), Value: aws.String("oldDevImage") },
-		&ec2.Tag{ Key: aws.String("Branch"), Value: aws.String("development") },
+		&ec2.Tag{Key: aws.String("Name"), Value: aws.String("oldDevImage")},
+		&ec2.Tag{Key: aws.String("Branch"), Value: aws.String("development")},
 	},
 	BlockDeviceMappings: []*ec2.BlockDeviceMapping{
 		&ec2.BlockDeviceMapping{
@@ -70,41 +70,41 @@ var oldDevImage = &ec2.Image{
 	},
 }
 
-var testImages = []*ec2.Image{ newMasterImage, newishDevImage, oldDevImage }
+var testImages = []*ec2.Image{newMasterImage, newishDevImage, oldDevImage}
 
 var now = time.Date(2019, 4, 1, 0, 0, 0, 0, time.UTC)
 
 func TestFindImagesToPurge(t *testing.T) {
 	logger, _ := zap.NewProduction()
 	tables := []struct {
-		imageSet []*ec2.Image
-		Branch string
+		imageSet      []*ec2.Image
+		Branch        string
 		RetentionDays int
-		resultSet []*ec2.Image
+		resultSet     []*ec2.Image
 	}{
-		{ testImages, "master", 1, []*ec2.Image(nil) },
-		{ testImages, "development", 30, []*ec2.Image{ oldDevImage } },
-		{ testImages, "development", 1, []*ec2.Image{ newishDevImage, oldDevImage } },
-		{ testImages, "!master", 1, []*ec2.Image{ newishDevImage, oldDevImage } },
+		{testImages, "master", 1, []*ec2.Image(nil)},
+		{testImages, "development", 30, []*ec2.Image{oldDevImage}},
+		{testImages, "development", 1, []*ec2.Image{newishDevImage, oldDevImage}},
+		{testImages, "!master", 1, []*ec2.Image{newishDevImage, oldDevImage}},
 	}
 
 	for _, table := range tables {
 		a := AMIClean{
-			Branch: table.Branch,
-			DryRun: true,
+			Branch:         table.Branch,
+			DryRun:         true,
 			ExpirationDate: now.AddDate(0, 0, -int(table.RetentionDays)),
-			Logger: logger,
-			EC2Client: nil,
+			Logger:         logger,
+			EC2Client:      nil,
 		}
 
-		output := &ec2.DescribeImagesOutput{ Images: testImages }
+		output := &ec2.DescribeImagesOutput{Images: testImages}
 		result := a.FindImagesToPurge(output)
 		if !reflect.DeepEqual(result, table.resultSet) {
 			t.Errorf("ERROR: branch %v, retention %d days failed;\n\texpected: %v\n\tgot: %v",
-			table.Branch,
-			table.RetentionDays,
-			table.resultSet,
-			result)
+				table.Branch,
+				table.RetentionDays,
+				table.resultSet,
+				result)
 		}
 	}
 }

--- a/pkg/amiclean/ami_cleaner_test.go
+++ b/pkg/amiclean/ami_cleaner_test.go
@@ -82,7 +82,7 @@ func TestFindImagesToPurge(t *testing.T) {
 		RetentionDays int
 		resultSet []*ec2.Image
 	}{
-		{ testImages, "master", 1, []*ec2.Image{} },
+		{ testImages, "master", 1, []*ec2.Image(nil) },
 		{ testImages, "development", 30, []*ec2.Image{ oldDevImage } },
 		{ testImages, "development", 1, []*ec2.Image{ newishDevImage, oldDevImage } },
 		{ testImages, "!master", 1, []*ec2.Image{ newishDevImage, oldDevImage } },


### PR DESCRIPTION
This is the current state of my AMI cleaner script; it is finally to the point where it builds and I can run some dry-runs, but I'm missing tests and, more importantly, the !branch functionality (so you can say delete everything that isn't part of the master branch, for instance). If I run this command:

main -n -b \!master --days=1

...it decides what I *actually* meant was to delete only master branch images, and I can't figure out why. I can tell that it is going into the NOT branch end of the if statement, so I don't know why it is deciding to add those images to the purgelist for some reason. Maybe someone else can figure out what I'm missing here.

This is probably going to be a throwaway pull request and I'll make another one when this is actually ready to be merged with a branchname that will link to the appropriate ticket -- before that happens I need to make sure it works and has tests though. Mostly what I'm looking for here is a) what am I doing wrong and b) is there any design issues that look like they should be fixed. I also need to make sure Lambda support is in here as well.

I based this largely on @dynamike's rdsclean stuff.