### PR TITLE
Add name filtering and replace branch with arbitrary tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ AWS tools that come in handy.
 | s3-bucket-size          | figures out how many bytes are in a given bucket as of the last CloudWatch metric update. Must faster and cheaper than iterating over all of the objects and usually "good enough". | No |
 | trusted-advisor-refresh | triggers a refresh of Trusted Advisor because AWS doesn't do this for you.                               | Yes                 |
 | aws-health-notifier     | Sends notifcations to a Slack webhook when AWS Health Events (read AWS outage) are triggered             | Yes                 |
+| ami-cleaner             | Deregisters AMIs and deletes associated snapshots based on name/tag/age                                  | Yes                 |
 
 ## Installation
 

--- a/cmd/ami-cleaner/main.go
+++ b/cmd/ami-cleaner/main.go
@@ -19,8 +19,8 @@ type Options struct {
 	Delete        bool   `short:"D" long:"delete" description:"Actually purge AMIs (runs in dryrun mode by default)."`
 	NamePrefix    string `long:"prefix" description:"Name prefix to filter on (not affected by --invert)."`
 	RetentionDays int    `long:"days" default:"30" description:"Age of AMI in days before it is a candidate for removal."`
-	TagKey        string `short:"k" long:"tag-key" description:"Key of tag to operate on. If you specify a Key, you must also specify a Value."`
-	TagValue      string `short:"v" long:"tag-value" description:"Value of tag to operate on. If you specify a Value, you must also specify a Key."`
+	TagKey        string `long:"tag-key" description:"Key of tag to operate on. If you specify a Key, you must also specify a Value."`
+	TagValue      string `long:"tag-value" description:"Value of tag to operate on. If you specify a Value, you must also specify a Key."`
 	Invert        bool   `short:"i" long:"invert" description:"Operate in inverted mode -- only purge AMIs that do NOT match the Tag provided."`
 	Profile       string `short:"p" long:"profile" env:"PROFILE" required:"false" description:"The AWS profile to use."`
 	Region        string `short:"r" long:"region" env:"REGION" required:"false" description:"The AWS region to use."`

--- a/cmd/ami-cleaner/main.go
+++ b/cmd/ami-cleaner/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/aws"
 	flag "github.com/jessevdk/go-flags"
 	"go.uber.org/zap"
 
@@ -39,7 +40,7 @@ func cleanImages() {
 	now := time.Now().UTC()
 	a := amiclean.AMIClean{
 		NamePrefix:	options.NamePrefix,
-		Branch:         options.Branch,
+		Tag:            &ec2.Tag{ Key: aws.String("Branch"), Value: aws.String(options.Branch)},
 		Delete:         options.Delete,
 		Invert:         options.Invert,
 		ExpirationDate: now.AddDate(0, 0, -int(options.RetentionDays)),

--- a/cmd/ami-cleaner/main.go
+++ b/cmd/ami-cleaner/main.go
@@ -16,6 +16,7 @@ import (
 // The Options struct describes the command line options available.
 type Options struct {
 	Delete        bool   `short:"D" long:"delete" description:"Actually purge AMIs (runs in dryrun mode by default)."`
+	NamePrefix    string `long:"prefix" description:"Name prefix to filter on (not affected by --invert)."`
 	RetentionDays int    `long:"days" default:"30" description:"Age of AMI in days before it is a candidate for removal."`
 	Branch        string `short:"b" long:"branch" required:"true" description:"Branch to purge. If the the --invert option is used, this is the branch NOT to operate on."`
 	Invert        bool   `short:"i" long:"invert" description:"Operate in inverted mode -- only purge AMIs that are NOT in the branch provided."`
@@ -37,6 +38,7 @@ func makeEC2Client(region, profile string) *ec2.EC2 {
 func cleanImages() {
 	now := time.Now().UTC()
 	a := amiclean.AMIClean{
+		NamePrefix:	options.NamePrefix,
 		Branch:         options.Branch,
 		Delete:         options.Delete,
 		Invert:         options.Invert,

--- a/cmd/ami-cleaner/main.go
+++ b/cmd/ami-cleaner/main.go
@@ -16,12 +16,12 @@ import (
 
 // The Options struct describes the command line options available.
 type Options struct {
-	Delete        bool   `short:"D" long:"delete" description:"Actually purge AMIs (runs in dryrun mode by default)."`
-	NamePrefix    string `long:"prefix" description:"Name prefix to filter on (not affected by --invert)."`
-	RetentionDays int    `long:"days" default:"30" description:"Age of AMI in days before it is a candidate for removal."`
-	TagKey        string `long:"tag-key" description:"Key of tag to operate on. If you specify a Key, you must also specify a Value."`
-	TagValue      string `long:"tag-value" description:"Value of tag to operate on. If you specify a Value, you must also specify a Key."`
-	Invert        bool   `short:"i" long:"invert" description:"Operate in inverted mode -- only purge AMIs that do NOT match the Tag provided."`
+	Delete        bool   `short:"D" long:"delete" env:"DELETE" description:"Actually purge AMIs (runs in dryrun mode by default)."`
+	NamePrefix    string `long:"prefix" env:"NAME_PREFIX" description:"Name prefix to filter on (not affected by --invert)."`
+	RetentionDays int    `long:"days" default:"30" env:"RETENTION_DAYS" description:"Age of AMI in days before it is a candidate for removal."`
+	TagKey        string `long:"tag-key" env:"TAG_KEY" description:"Key of tag to operate on. If you specify a Key, you must also specify a Value."`
+	TagValue      string `long:"tag-value" env:"TAG_VALUE" description:"Value of tag to operate on. If you specify a Value, you must also specify a Key."`
+	Invert        bool   `short:"i" long:"invert" env:"INVERT" description:"Operate in inverted mode -- only purge AMIs that do NOT match the Tag provided."`
 	Profile       string `short:"p" long:"profile" env:"PROFILE" required:"false" description:"The AWS profile to use."`
 	Region        string `short:"r" long:"region" env:"REGION" required:"false" description:"The AWS region to use."`
 	Lambda        bool   `long:"lambda" required:"false" env:"LAMBDA" description:"Run as an AWS Lambda function."`

--- a/pkg/amiclean/ami_cleaner.go
+++ b/pkg/amiclean/ami_cleaner.go
@@ -40,6 +40,7 @@ func (a *AMIClean) GetImages() (*ec2.DescribeImagesOutput, error) {
 				Values: []*string{aws.String("false")},
 			},
 		},
+		Owners: []*string{aws.String("self")},
 	}
 
 	output, err := a.EC2Client.DescribeImages(input)

--- a/pkg/amiclean/ami_cleaner.go
+++ b/pkg/amiclean/ami_cleaner.go
@@ -14,8 +14,8 @@ const (
 	RFC8601 = "2006-01-02T15:04:05.000Z"
 )
 
-// AMIClean defines parameters for cleaning up AMIs based on the Branch and
-// Expiration Date.
+// AMIClean defines parameters for cleaning up AMIs based on a tag and
+// expiration date.
 type AMIClean struct {
 	NamePrefix     string
 	Delete         bool
@@ -88,8 +88,8 @@ func (a *AMIClean) FindImagesToPurge(output *ec2.DescribeImagesOutput) []*ec2.Im
 				// AMIClean struct.
 				match, matchedTag := matchTags(image, a.Tag)
 
-				// If invert is set, we're looking for AMIs which are
-				// NOT in the branch selected.
+				// If invert is set, we're looking for AMIs which do
+				// NOT match the specified tag.
 				if a.Invert {
 					match, matchedTag := matchTags(image, a.Tag)
 					if !match {
@@ -111,8 +111,8 @@ func (a *AMIClean) FindImagesToPurge(output *ec2.DescribeImagesOutput) []*ec2.Im
 						ImagesToPurge =
 							append(ImagesToPurge, image)
 					}
-					// Otherwise, we're looking at all the AMIs with Branch
-					// set to whatever we set it to in the command line.
+					// Otherwise, we're looking at all the AMIs which do
+					// match the specified tag.
 				} else {
 					if match {
 						// Same note as above.

--- a/pkg/amiclean/ami_cleaner.go
+++ b/pkg/amiclean/ami_cleaner.go
@@ -34,12 +34,6 @@ func (a *AMIClean) GetImages() (*ec2.DescribeImagesOutput, error) {
 	var output *ec2.DescribeImagesOutput
 
 	input := &ec2.DescribeImagesInput{
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String("is-public"),
-				Values: []*string{aws.String("false")},
-			},
-		},
 		Owners: []*string{aws.String("self")},
 	}
 

--- a/pkg/amiclean/ami_cleaner.go
+++ b/pkg/amiclean/ami_cleaner.go
@@ -60,12 +60,12 @@ func matchTags(image *ec2.Image, tag *ec2.Tag) (bool, *ec2.Tag) {
 				// If the tag exists, and has the value we're
 				// looking for, return true and the image tag.
 				return true, imageTag
-			} else {
-				// If the tag exists, and doesn't have the
-				// value we're looking for, return false and
-				// the image tag.
-				return false, imageTag
 			}
+			// If the tag exists, and doesn't have the
+			// value we're looking for, return false and
+			// the image tag.
+			return false, imageTag
+
 		}
 	}
 

--- a/pkg/amiclean/ami_cleaner_test.go
+++ b/pkg/amiclean/ami_cleaner_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 var newMasterImage = &ec2.Image{
+	Name:         aws.String("masterimage-alpha"),
 	Description:  aws.String("New Master Image"),
 	ImageId:      aws.String("ami-11111111111111111"),
 	CreationDate: aws.String("2019-03-31T21:04:57.000Z"),
@@ -30,6 +31,7 @@ var newMasterImage = &ec2.Image{
 }
 
 var newishDevImage = &ec2.Image{
+	Name:         aws.String("devimage-alpha"),
 	Description:  aws.String("Newish Dev Image"),
 	ImageId:      aws.String("ami-22222222222222222"),
 	CreationDate: aws.String("2019-03-30T21:04:57.000Z"),
@@ -55,12 +57,14 @@ var newishDevImage = &ec2.Image{
 }
 
 var oldDevImage = &ec2.Image{
+	Name:         aws.String("devimage-bravo"),
 	Description:  aws.String("Old Dev Image"),
 	ImageId:      aws.String("ami-33333333333333333"),
 	CreationDate: aws.String("2019-03-01T21:04:57.000Z"),
 	Tags: []*ec2.Tag{
 		&ec2.Tag{Key: aws.String("Name"), Value: aws.String("oldDevImage")},
 		&ec2.Tag{Key: aws.String("Branch"), Value: aws.String("development")},
+		&ec2.Tag{Key: aws.String("Foozle"), Value: aws.String("Fizzbin")},
 	},
 	BlockDeviceMappings: []*ec2.BlockDeviceMapping{
 		&ec2.BlockDeviceMapping{
@@ -74,12 +78,14 @@ var oldDevImage = &ec2.Image{
 }
 
 var noEbsImage = &ec2.Image{
+	Name:         aws.String("experiment-alpha"),
 	Description:  aws.String("No EBS Image"),
 	ImageId:      aws.String("ami-44444444444444444"),
 	CreationDate: aws.String("2019-03-01T21:04:57.000Z"),
 	Tags: []*ec2.Tag{
 		&ec2.Tag{Key: aws.String("Name"), Value: aws.String("noEbsImage")},
 		&ec2.Tag{Key: aws.String("Branch"), Value: aws.String("experimental")},
+		&ec2.Tag{Key: aws.String("Foozle"), Value: aws.String("Whatsit")},
 	},
 	RootDeviceType: aws.String("instance-store"),
 }

--- a/pkg/amiclean/ami_cleaner_test.go
+++ b/pkg/amiclean/ami_cleaner_test.go
@@ -105,18 +105,18 @@ func TestFindImagesToPurge(t *testing.T) {
 		RetentionDays int
 		resultSet     []*ec2.Image
 	}{
-		{testImages, "", &ec2.Tag{ Key: aws.String("Branch"), Value: aws.String("master")}, false, 1, []*ec2.Image(nil)},
-		{testImages, "", &ec2.Tag{ Key: aws.String("Branch"), Value: aws.String("development")}, false, 30, []*ec2.Image{oldDevImage}},
-		{testImages, "", &ec2.Tag{ Key: aws.String("Branch"), Value: aws.String("development")}, false, 1, []*ec2.Image{newishDevImage, oldDevImage}},
-		{testImages, "", &ec2.Tag{ Key: aws.String("Branch"), Value: aws.String("master")}, true, 1, []*ec2.Image{newishDevImage, oldDevImage, noEbsImage}},
-		{testImages, "devimage", &ec2.Tag{ Key: aws.String("Branch"), Value: aws.String("master")}, true, 1, []*ec2.Image{newishDevImage, oldDevImage}},
-		{testImages, "", &ec2.Tag{ Key: aws.String("Foozle"), Value: aws.String("Whatsit")}, false, 1, []*ec2.Image{noEbsImage}},
-		{testImages, "", &ec2.Tag{ Key: aws.String("Foozle"), Value: aws.String("Whatsit")}, true, 0, []*ec2.Image{newMasterImage, newishDevImage, oldDevImage}},
+		{testImages, "", &ec2.Tag{Key: aws.String("Branch"), Value: aws.String("master")}, false, 1, []*ec2.Image(nil)},
+		{testImages, "", &ec2.Tag{Key: aws.String("Branch"), Value: aws.String("development")}, false, 30, []*ec2.Image{oldDevImage}},
+		{testImages, "", &ec2.Tag{Key: aws.String("Branch"), Value: aws.String("development")}, false, 1, []*ec2.Image{newishDevImage, oldDevImage}},
+		{testImages, "", &ec2.Tag{Key: aws.String("Branch"), Value: aws.String("master")}, true, 1, []*ec2.Image{newishDevImage, oldDevImage, noEbsImage}},
+		{testImages, "devimage", &ec2.Tag{Key: aws.String("Branch"), Value: aws.String("master")}, true, 1, []*ec2.Image{newishDevImage, oldDevImage}},
+		{testImages, "", &ec2.Tag{Key: aws.String("Foozle"), Value: aws.String("Whatsit")}, false, 1, []*ec2.Image{noEbsImage}},
+		{testImages, "", &ec2.Tag{Key: aws.String("Foozle"), Value: aws.String("Whatsit")}, true, 0, []*ec2.Image{newMasterImage, newishDevImage, oldDevImage}},
 	}
 
 	for _, table := range tables {
 		a := AMIClean{
-			NamePrefix:	table.NamePrefix,
+			NamePrefix:     table.NamePrefix,
 			Tag:            table.Tag,
 			Invert:         table.Invert,
 			Delete:         false,
@@ -127,9 +127,9 @@ func TestFindImagesToPurge(t *testing.T) {
 
 		output := &ec2.DescribeImagesOutput{Images: testImages}
 		result := a.FindImagesToPurge(output)
-		var result_names []string
-		for _, result_item := range result {
-			result_names = append(result_names, *result_item.Name)
+		var resultNames []string
+		for _, resultItem := range result {
+			resultNames = append(resultNames, *resultItem.Name)
 		}
 		if !reflect.DeepEqual(result, table.resultSet) {
 			t.Errorf("ERROR: prefix: %v, branch %v, invert %v, retention %v;\n\texpected: %v\n\tgot: %v",
@@ -138,7 +138,7 @@ func TestFindImagesToPurge(t *testing.T) {
 				table.Invert,
 				table.RetentionDays,
 				table.resultSet,
-				result_names)
+				resultNames)
 		}
 	}
 }
@@ -149,7 +149,7 @@ func TestFindImagesToPurge(t *testing.T) {
 // working right.
 func TestPurgeImages(t *testing.T) {
 	a := AMIClean{
-		Tag:            &ec2.Tag{ Key: aws.String("Branch"), Value: aws.String("master")},
+		Tag:            &ec2.Tag{Key: aws.String("Branch"), Value: aws.String("master")},
 		Invert:         true,
 		Delete:         false,
 		ExpirationDate: now.AddDate(0, 0, -1),


### PR DESCRIPTION
So, I have fixed up the amicleaner by improving some logging, allowing name filtering, and changing the --branch option to the more general --tag-key and --tag-value options.

This change successfully passes tests and mostly works in my real-world test environment, but I am running into an issue I'm not entirely sure about. This error seems to come up when I run the command line tool and get a large (>10) number of results:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x16582ac]

goroutine 1 [running]:
github.com/trussworks/truss-aws-tools/pkg/amiclean.(*AMIClean).PurgeImages(0xc000133ed0, 0xc000272180, 0xc, 0x10, 0x10, 0xffffffffffffffe2)
	/Users/cblkwell/go/src/github.com/trussworks/truss-aws-tools/pkg/amiclean/ami_cleaner.go:166 +0x2dc
main.cleanImages()
	/Users/cblkwell/go/src/github.com/trussworks/truss-aws-tools/cmd/ami-cleaner/main.go:67 +0x4f0
main.main()
	/Users/cblkwell/go/src/github.com/trussworks/truss-aws-tools/cmd/ami-cleaner/main.go:99 +0x1d8
exit status 2
```
I don't really understand why that line is causing problems, or what is going on here...I suspect this is me not doing a good job of memory hygiene.

One improvement I think may help is changing PurgeImages to a PurgeImage function that would operate on each image as it is found in the FindImagesToPurge function, but that is a fair bit of reengineering, so I wanted to checkpoint myself here and see if someone knows where I might be running into the weeds.