### PR TITLE
Adding ami-cleaner bits to Makefile scripts and bumping version to 2.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/sh
-VERSION = 2.6
+VERSION = 2.7
 
 all: install
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,6 @@ make S3_BUCKET=your-s3-bucket lambda_release
 ## Tools wanted
 
 * s3 deletion tool that purges a key AND all versions of that key.
-* ami-deregister that doesn't touch AMIs that are currently active or have been recently.
 * ebs volume snapshot deleter (all snaps older than x days, support keep tags)
 * redshift snapshot cleaner
 * automatic filesystem resizer (use case: you can make EBS volumes larger, but if you do, you still have to go in and run resize2fs (or whatever). Why not just do this at boot always?

--- a/bin/make-lambda-build
+++ b/bin/make-lambda-build
@@ -11,7 +11,7 @@ cleanup() {
 trap "cleanup" EXIT INT
 
 readonly build_dir=$(mktemp -d)
-readonly lambda_tools="rds-snapshot-cleaner trusted-advisor-refresh iam-keys-check rds-cloudwatch-logs aws-health-notifier"
+readonly lambda_tools="rds-snapshot-cleaner trusted-advisor-refresh iam-keys-check rds-cloudwatch-logs aws-health-notifier ami-cleaner"
 mkdir -p "$build_dir"
 
 for cmd in $lambda_tools


### PR DESCRIPTION
This just adds in the goo needed to use ami-cleaner in an actual release and bumps the version appropriately, will tag once this is merged in.