### PR TITLE
Enable disabled checks copied from MilMove

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
             - dot-cache-pre-commit-{{ checksum ".pre-commit-config.yaml" }}
       - restore_cache:
           keys:
-            - go-mod-sources-v1-{{ checksum "go.sum" }}
+            - go-mod-sources-v2-{{ checksum "go.sum" }}
       - run:
           name: Adding go binaries to $PATH
           command: |
@@ -27,7 +27,7 @@ jobs:
           paths:
             - ~/.cache/pre-commit
       - save_cache:
-          key: go-mod-sources-v1-{{ checksum "go.sum" }}
+          key: go-mod-sources-v2-{{ checksum "go.sum" }}
           paths:
             - "~/go/pkg/mod"
       - store_test_results:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,4 +29,3 @@ issues:
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 8m
-  concurrency: 1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,8 @@ linters-settings:
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
           - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+      govet:
+        check-shadowing: true
 linters:
   enable:
      - gosec
@@ -17,20 +19,14 @@ linters:
      - typecheck
      - structcheck
      - deadcode
-  disable:
-    - unused #deprecated https://github.com/dominikh/go-tools/tree/master/cmd/unused
-    - errcheck #requires patching code
-    - gosimple # 20+ files need to be patched
-    - ineffassign # 20+ files need to be patched
-    - staticcheck # 30+files need to be patched
+     - errcheck
+     - gosimple
+     - ineffassign
+     - staticcheck
+     - unused
 issues:
   fix: true
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 8m
   concurrency: 1
-
-# which dirs to skip: they won't be analyzed;
-  skip-dirs:
-    - pkg/gen
-    - mocks

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ go get -u github.com/trussworks/truss-aws-tools/...
 
 ``` shell
 brew install pre-commit direnv
-go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+brew install golangci/tap/golangci-lint
 ```
 
 Then run `./bin/prereqs` and follow any instructions that appear.


### PR DESCRIPTION
The golangci-lint config we used was pulled from https://github.com/transcom/mymove/blob/master/.golangci.yml. All of the disabled checks didn't apply to this repo, so I'm turning them on. 