### PR TITLE
Add support for optional tag key

### DIFF
--- a/pkg/amiclean/ami_cleaner.go
+++ b/pkg/amiclean/ami_cleaner.go
@@ -51,10 +51,11 @@ func (a *AMIClean) GetImages() (*ec2.DescribeImagesOutput, error) {
 // within an image.
 func matchTags(image *ec2.Image, tag *ec2.Tag) (bool, *ec2.Tag) {
 	for _, imageTag := range image.Tags {
-		if *tag.Key == *imageTag.Key {
-			if *tag.Value == *imageTag.Value {
+		if *tag.Key == "" || *tag.Key == *imageTag.Key {
+			if *tag.Value == "" || *tag.Value == *imageTag.Value {
 				// If the tag exists, and has the value we're
-				// looking for, return true and the image tag.
+				// looking for or we don't need match the tag,
+				// return true and the image tag.
 				return true, imageTag
 			}
 			// If the tag exists, and doesn't have the

--- a/pkg/amiclean/ami_cleaner_test.go
+++ b/pkg/amiclean/ami_cleaner_test.go
@@ -111,6 +111,9 @@ func TestCheckImage(t *testing.T) {
 		{testImages, "devimage", &ec2.Tag{Key: aws.String("Branch"), Value: aws.String("master")}, true, 1, []bool{false, true, true, false}},
 		{testImages, "", &ec2.Tag{Key: aws.String("Foozle"), Value: aws.String("Whatsit")}, false, 1, []bool{false, false, false, true}},
 		{testImages, "", &ec2.Tag{Key: aws.String("Foozle"), Value: aws.String("Whatsit")}, true, 0, []bool{true, true, true, false}},
+		{testImages, "", nil, true, 0, []bool{true, true, true, false}},
+		{testImages, "", nil, false, 1, []bool{true, false, true, false}},
+		{testImages, "testimage", nil, false, 10, []bool{true, false, true, true}},
 	}
 
 	for _, table := range tables {


### PR DESCRIPTION
According to https://github.com/trussworks/truss-aws-tools/blob/master/cmd/ami-cleaner/README.md#usage, the `--tag-key` can be optional but original `matchTags()` returns false if tag key is not set.

This PR adds the support for optional `--tag-key` 