### PR TITLE
Add checker for empty Ebs structure to avoid nil pointer dereference

### DIFF
--- a/pkg/amiclean/ami_cleaner.go
+++ b/pkg/amiclean/ami_cleaner.go
@@ -179,8 +179,10 @@ func (a *AMIClean) PurgeImage(image *ec2.Image) (string, error) {
 		// so we need to build a list and iterate on them.
 		var snapshotIds []*string
 		for _, blockDevice := range image.BlockDeviceMappings {
-			snapshotID := *blockDevice.Ebs.SnapshotId
-			snapshotIds = append(snapshotIds, &snapshotID)
+			if blockDevice.Ebs != nil {
+				snapshotID := *blockDevice.Ebs.SnapshotId
+				snapshotIds = append(snapshotIds, &snapshotID)
+			}
 		}
 		deregisterInput := &ec2.DeregisterImageInput{
 			DryRun:  aws.Bool(!a.Delete),

--- a/pkg/amiclean/ami_cleaner_test.go
+++ b/pkg/amiclean/ami_cleaner_test.go
@@ -25,6 +25,10 @@ var newMasterImage = &ec2.Image{
 				SnapshotId: aws.String("snap-11111111111111111"),
 			},
 		},
+		{
+			DeviceName:  aws.String("/dev/sdb"),
+			VirtualName: aws.String("ephemeral0"),
+		},
 	},
 	RootDeviceType: aws.String("ebs"),
 }
@@ -51,6 +55,14 @@ var newishDevImage = &ec2.Image{
 				SnapshotId: aws.String("snap-22222222222222223"),
 			},
 		},
+		{
+			DeviceName:  aws.String("/dev/sdb"),
+			VirtualName: aws.String("ephemeral0"),
+		},
+		{
+			DeviceName:  aws.String("/dev/sdc"),
+			VirtualName: aws.String("ephemeral1"),
+		},
 	},
 	RootDeviceType: aws.String("ebs"),
 }
@@ -71,6 +83,10 @@ var oldDevImage = &ec2.Image{
 			Ebs: &ec2.EbsBlockDevice{
 				SnapshotId: aws.String("snap-33333333333333333"),
 			},
+		},
+		{
+			DeviceName:  aws.String("/dev/sdb"),
+			VirtualName: aws.String("ephemeral0"),
 		},
 	},
 	RootDeviceType: aws.String("ebs"),


### PR DESCRIPTION
I met this panic error when run `ami-cleaner`
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x16944ff]

goroutine 1 [running]:
github.com/trussworks/truss-aws-tools/pkg/amiclean.(*AMIClean).PurgeImage(0xc000133ed0, 0xc0002ac0f0, 0x1, 0x0, 0xc0000c4020, 0xfffffffffffffffd)
	/Codes/go/src/github.com/trussworks/truss-aws-tools/pkg/amiclean/ami_cleaner.go:184 +0xdf
main.cleanImages()
	/Codes/go/src/github.com/trussworks/truss-aws-tools/cmd/ami-cleaner/main.go:72 +0x542
main.main()
	/Codes/go/src/github.com/trussworks/truss-aws-tools/cmd/ami-cleaner/main.go:120 +0x1d8
```

Then I found there are some other elements in struct `BlockDeviceMappings` in our AMI when I run `aws ec2 describe-images --image-ids XXX`

```
            "BlockDeviceMappings": [
                {
                    "DeviceName": "/dev/sda1",
                    "Ebs": {
                        "DeleteOnTermination": true,
                        "SnapshotId": "snap-XXXXX",
                        "VolumeSize": 8,
                        "VolumeType": "gp2",
                        "Encrypted": false
                    }
                },
                {
                    "DeviceName": "/dev/xvdf",
                    "Ebs": {
                        "DeleteOnTermination": true,
                        "SnapshotId": "snap-YYYYY",
                        "VolumeSize": 100,
                        "VolumeType": "gp2",
                        "Encrypted": false
                    }
                },
                {
                    "DeviceName": "/dev/sdb",
                    "VirtualName": "ephemeral0"
                },
                {
                    "DeviceName": "/dev/sdc",
                    "VirtualName": "ephemeral1"
                }
            ],
```

So this PR adds a checker to see if `BlockDeviceMappings.Ebs` exists or not to avoid the panic error,