### PR TITLE
Have tests bail out on failures

### DIFF
--- a/bin/make-test
+++ b/bin/make-test
@@ -6,7 +6,7 @@ go_test_output="/tmp/go-test.out"
 
 go test -v github.com/trussworks/truss-aws-tools/... | tee "${go_test_output}"
 
-if [[ -z ${CIRCLECI-} ]]; then
+if [[ -n ${CIRCLECI-} ]]; then
     mkdir -p "${TEST_RESULTS}"/gotest
     go-junit-report < "${go_test_output}" \
                     > "${TEST_RESULTS}/gotest/go-test-report.xml"

--- a/bin/make-test
+++ b/bin/make-test
@@ -6,6 +6,10 @@ go_test_output="/tmp/go-test.out"
 
 go test -v github.com/trussworks/truss-aws-tools/... | tee "${go_test_output}"
 
+
+# Check if we are running tests inside of CircleCI by checking for a $CIRCLECI
+# environment variable. The dash after $CIRCLECI substitutes a null value if
+# CIRCLECI is unset. This prevents unbound variable errors
 if [[ -n ${CIRCLECI-} ]]; then
     mkdir -p "${TEST_RESULTS}"/gotest
     go-junit-report < "${go_test_output}" \

--- a/bin/make-test
+++ b/bin/make-test
@@ -1,10 +1,12 @@
-#! /bin/sh
+#!/usr/bin/env bash
+
+set -eu -o pipefail
 
 go_test_output="/tmp/go-test.out"
 
 go test -v github.com/trussworks/truss-aws-tools/... | tee "${go_test_output}"
 
-if [ -n "$CIRCLECI" ]; then
+if [[ -z ${CIRCLECI-} ]]; then
     mkdir -p "${TEST_RESULTS}"/gotest
     go-junit-report < "${go_test_output}" \
                     > "${TEST_RESULTS}/gotest/go-test-report.xml"

--- a/pkg/packerjanitor/packer_janitor_test.go
+++ b/pkg/packerjanitor/packer_janitor_test.go
@@ -157,7 +157,7 @@ func TestGetPackerInstancesSuccess(t *testing.T) {
 
 	testSet, err := p.GetPackerInstances()
 
-	if err == nil {
+	if err != nil {
 		t.Errorf("ERROR: GetPackerInstances threw error during successful test")
 	}
 

--- a/pkg/packerjanitor/packer_janitor_test.go
+++ b/pkg/packerjanitor/packer_janitor_test.go
@@ -157,7 +157,7 @@ func TestGetPackerInstancesSuccess(t *testing.T) {
 
 	testSet, err := p.GetPackerInstances()
 
-	if err != nil {
+	if err == nil {
 		t.Errorf("ERROR: GetPackerInstances threw error during successful test")
 	}
 


### PR DESCRIPTION
It looks like failed tests weren't propagating to CircleCI because we were swallowing the non zero exit code. This PR fixes that. 

https://circleci.com/gh/trussworks/truss-aws-tools/280?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link