### PR TITLE
Remove username from script and use variable

### DIFF
--- a/bin/aws-remove-user
+++ b/bin/aws-remove-user
@@ -60,7 +60,7 @@ esac
 # Remove Access Keys
 #
 
-ACCESS_KEYS=$(aws iam list-access-keys --user-name maz | jq -r ".AccessKeyMetadata[].AccessKeyId")
+ACCESS_KEYS=$(aws iam list-access-keys --user-name "${USERNAME}" | jq -r ".AccessKeyMetadata[].AccessKeyId")
 if [ -z "${ACCESS_KEYS}" ]; then
   echo "No Access Keys to delete"
 else


### PR DESCRIPTION
I wasn't very careful when adding https://github.com/trussworks/truss-aws-tools/pull/101 and a username slipped in. This ought to fix it.

Credit to @kilbergr for finding this one!