### PR TITLE
Support more than US-East-1, since this exists in GovCloud regions.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/sh
-VERSION = 2.9
+VERSION = 3.0
 
 all: install
 

--- a/cmd/trusted-advisor-refresh/main.go
+++ b/cmd/trusted-advisor-refresh/main.go
@@ -16,6 +16,7 @@ import (
 type Options struct {
 	Profile string `short:"p" long:"profile" description:"The AWS profile to use." required:"false" env:"AWS_PROFILE"`
 	Lambda  bool   `short:"l" long:"lambda" description:"Run as an AWS lambda function." required:"false" env:"LAMBDA"`
+	Region  string `long:"region" description:"The AWS region to use." required:"false" env:"AWS_REGION"`
 }
 
 var options Options
@@ -29,7 +30,7 @@ func makeSupportClient(region, profile string) *support.Support {
 
 func triggerRefresh() {
 	// Trusted Advisor only works in us-east-1
-	supportClient := makeSupportClient("us-east-1", options.Profile)
+	supportClient := makeSupportClient(options.Region, options.Profile)
 
 	tar := tarefresh.TrustedAdvisorRefresh{
 		Logger:        logger,


### PR DESCRIPTION
`trusted-advisor-refresh` lambda had hard-coded `us-east-1` which may still be true for AWS Commercial, but Trusted Advisor is available in GovCloud regions. This supports passing a region and/or using `AWS_REGION` env var. 