### PR TITLE
Check for unused ami images across multiple aws accounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL = /bin/sh
-VERSION = 3.0
+VERSION = 3.1
 
 all: install
 

--- a/cmd/ami-cleaner/main.go
+++ b/cmd/ami-cleaner/main.go
@@ -23,6 +23,7 @@ type Options struct {
 	TagValue      string `long:"tag-value" env:"TAG_VALUE" description:"Value of tag to operate on. If you specify a Value, you must also specify a Key."`
 	Invert        bool   `short:"i" long:"invert" env:"INVERT" description:"Operate in inverted mode -- only purge AMIs that do NOT match the Tag provided."`
 	Unused        bool   `long:"unused" env:"UNUSED" description:"Only purge AMIs for which no running instances were built from."`
+	Role          string `long:"sts-role" env:"STS_ROLE" required:"false" description:"The AWS IAM Role name used for cross-account unused AMIs checking."`
 	Profile       string `short:"p" long:"profile" env:"AWS_PROFILE" required:"false" description:"The AWS profile to use."`
 	Region        string `short:"r" long:"region" env:"AWS_REGION" required:"false" description:"The AWS region to use."`
 	Lambda        bool   `long:"lambda" required:"false" env:"LAMBDA" description:"Run as an AWS Lambda function."`
@@ -30,13 +31,6 @@ type Options struct {
 
 var options Options
 var logger *zap.Logger
-
-// This function is for establishing our session with AWS.
-func makeEC2Client(region, profile string) *ec2.EC2 {
-	sess := session.MustMakeSession(region, profile)
-	ec2Client := ec2.New(sess)
-	return ec2Client
-}
 
 func cleanImages() {
 	now := time.Now().UTC()
@@ -46,15 +40,19 @@ func cleanImages() {
 		logger.Fatal("must specify both a tag Key and tag Value")
 	}
 
+	sess := session.MustMakeSession(options.Region, options.Profile)
+
 	a := amiclean.AMIClean{
 		NamePrefix:     options.NamePrefix,
 		Tag:            &ec2.Tag{Key: aws.String(options.TagKey), Value: aws.String(options.TagValue)},
 		Delete:         options.Delete,
 		Invert:         options.Invert,
 		Unused:         options.Unused,
+		Role:           options.Role,
 		ExpirationDate: now.AddDate(0, 0, -int(options.RetentionDays)),
 		Logger:         logger,
-		EC2Client:      makeEC2Client(options.Region, options.Profile),
+		EC2Client:      session.MakeEC2Client(sess),
+		STSClient:      session.MakeSTSClient(sess),
 	}
 
 	// Get the list of images that we want to evaluate from AWS.

--- a/internal/aws/session/session.go
+++ b/internal/aws/session/session.go
@@ -2,7 +2,10 @@ package session
 
 import (
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/sts"
 )
 
 // MakeSession creates an AWS Session, with appropriate defaults,
@@ -22,8 +25,37 @@ func MakeSession(region, profile string) (*session.Session, error) {
 	return session.NewSessionWithOptions(sessOpts)
 }
 
+// MakeSessionWithSTSCredentials creates an AWS Session, with appropriate defaults,
+// using custom AWS STS credentials
+func MakeSessionWithSTSCredentials(stsCredentials *sts.Credentials) (*session.Session, error) {
+	awsConfig := aws.Config{
+		Credentials: credentials.NewStaticCredentials(*stsCredentials.AccessKeyId, *stsCredentials.SecretAccessKey, *stsCredentials.SessionToken),
+		Region:      aws.String("us-east-1"),
+	}
+	sessOpts := session.Options{
+		Config: awsConfig,
+	}
+	return session.NewSessionWithOptions(sessOpts)
+}
+
+// MustMakeSessionWithSTSCredentials creates an AWS Session using MakeSessionWithSTSCredentials and ensures
+// that it is valid.
+func MustMakeSessionWithSTSCredentials(credentials *sts.Credentials) *session.Session {
+	return session.Must(MakeSessionWithSTSCredentials(credentials))
+}
+
 // MustMakeSession creates an AWS Session using MakeSession and ensures
 // that it is valid.
 func MustMakeSession(region, profile string) *session.Session {
 	return session.Must(MakeSession(region, profile))
+}
+
+// MakeEC2Client makes an AWS EC2 client from an AWS Session.
+func MakeEC2Client(session *session.Session) *ec2.EC2 {
+	return ec2.New(session)
+}
+
+// MakeSTSClient makes an AWS STS client from an AWS Session.
+func MakeSTSClient(session *session.Session) *sts.STS {
+	return sts.New(session)
 }

--- a/pkg/amiclean/ami_cleaner.go
+++ b/pkg/amiclean/ami_cleaner.go
@@ -1,8 +1,12 @@
 package amiclean
 
 import (
+	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/trussworks/truss-aws-tools/internal/aws/session"
 	"go.uber.org/zap"
 
 	"strings"
@@ -22,9 +26,11 @@ type AMIClean struct {
 	Tag            *ec2.Tag
 	Invert         bool
 	Unused         bool
+	Role           string
 	ExpirationDate time.Time
 	Logger         *zap.Logger
 	EC2Client      *ec2.EC2
+	STSClient      *sts.STS
 }
 
 // GetImages gets us all the private AMIs on our account so that they can be
@@ -71,39 +77,93 @@ func matchTags(image *ec2.Image, tag *ec2.Tag) (bool, *ec2.Tag) {
 	return false, &ec2.Tag{Key: tag.Key, Value: aws.String("not found")}
 }
 
+func (a *AMIClean) getImageLaunchPermission(image *ec2.Image) ([]*ec2.LaunchPermission, error) {
+	// Create an input into DescribeImageAttributeInput to retrieve image launch permissions.
+	describeImageAttributeInput := &ec2.DescribeImageAttributeInput{
+		Attribute: aws.String("launchPermission"),
+		ImageId:   image.ImageId,
+	}
+	output, err := a.EC2Client.DescribeImageAttribute(describeImageAttributeInput)
+	if err != nil {
+		return nil, err
+	}
+	return output.LaunchPermissions, nil
+}
+
+func (a *AMIClean) checkAccountUnused(ec2Client *ec2.EC2, accountID *string, image *ec2.Image) (bool, error) {
+
+	amiFilter := &ec2.Filter{
+		Name:   aws.String("image-id"),
+		Values: []*string{image.ImageId},
+	}
+
+	findInstancesInput := &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{amiFilter},
+	}
+
+	output, err := ec2Client.DescribeInstances(findInstancesInput)
+	if err != nil {
+		return false, err
+	}
+
+	if output.Reservations != nil {
+		a.Logger.Info("found image running instance in aws account",
+			zap.String("account-id", *accountID),
+			zap.String("ami-id", *image.ImageId),
+		)
+		return false, nil
+	}
+
+	return true, nil
+}
+
 // CheckUnused takes an image and then checks to see if it is in use
-// as an instance. If the image is in use, it should return false; if it
-// is not in use, it should return true. Note that we're only checking for
-// AMIs we own with this account in this account; if we've shared them
-// with other accounts, we have no idea if they are being used (and
-// finding out is nontrivial, unfortunately).
+// on a running ec2 instance. If a cross account sts role has
+// been provided, it checks on the image owner and all aws accounts listed in
+// the image launch permissions.
+// If a cross account sts role hasn't been provided, it checks
+// on the image owner account only.
+// If the image is in use, it should return false; if it
+// is not in use, it should return true.
 // TODO: Also check to see if we are using it for any ASG launch
 // configurations. This is more difficult because you cannot filter them
 // by AMI ID like you can with instances; you have to fetch all of them
 // and then parse through them doing the comparison, making it much more
 // onerous. :/
 func (a *AMIClean) CheckUnused(image *ec2.Image) (bool, error) {
-	// First we define a filter we can use.
-	amiFilter := &ec2.Filter{
-		Name:   aws.String("image-id"),
-		Values: []*string{image.ImageId},
+
+	if a.Role == "" {
+		return a.checkAccountUnused(a.EC2Client, image.OwnerId, image)
 	}
-	// Now, we use that filter to create an input into DescribeInstances.
-	findInstancesInput := &ec2.DescribeInstancesInput{
-		Filters: []*ec2.Filter{amiFilter},
-	}
-	output, err := a.EC2Client.DescribeInstances(findInstancesInput)
+
+	imageAccountIDs := []*string{image.OwnerId}
+
+	imageLaunchPermissions, err := a.getImageLaunchPermission(image)
 	if err != nil {
 		return false, err
 	}
 
-	// If the Reservations attribute in the output isn't empty, then we
-	// know something is using that AMI and we can return false.
-	if output.Reservations != nil {
-		return false, nil
+	for _, imageLaunchPermission := range imageLaunchPermissions {
+		imageAccountIDs = append(imageAccountIDs, imageLaunchPermission.UserId)
 	}
 
-	// If we've gotten to this point, this AMI is unused.
+	for _, imageAccountID := range imageAccountIDs {
+		assumeRoleOutput, err := a.STSClient.AssumeRole(&sts.AssumeRoleInput{
+			RoleArn:         aws.String(fmt.Sprintf("arn:aws:iam::%s:role/%s", *imageAccountID, a.Role)),
+			RoleSessionName: aws.String(fmt.Sprintf("ami-cleaner-%s", a.NamePrefix)),
+		})
+
+		if err != nil {
+			return false, err
+		}
+
+		stsEC2Client := session.MakeEC2Client(session.MustMakeSessionWithSTSCredentials(assumeRoleOutput.Credentials))
+
+		if result, err := a.checkAccountUnused(stsEC2Client, imageAccountID, image); err != nil || !result {
+			return result, err
+		}
+	}
+
 	return true, nil
 }
 

--- a/pkg/amiclean/ami_cleaner_test.go
+++ b/pkg/amiclean/ami_cleaner_test.go
@@ -188,6 +188,7 @@ func TestPurgeImage(t *testing.T) {
 		ExpirationDate: now.AddDate(0, 0, -1),
 		Logger:         logger,
 		EC2Client:      nil,
+		STSClient:      nil,
 	}
 
 	for _, image := range testImages {


### PR DESCRIPTION
Currently, the check for unused AMI image before de-registration and EBS snapshot deletion happens on the AWS account the ami-cleaner is invoked from.

An EC2 AMI can be shared with different AWS accounts, which will be delegated permissions launching the AMI. These permissions are part of the AMI attributes.

We use the permissions to identify which AWS accounts have the privileges launching the AMI, and we use AWS STS to use pre-defined "readonly" IAM "jump" roles in these accounts, so that we can check them for running EC2 instances and prevent EC2 AMI deletion.

* the check will be performed on all the aws accounts the ami has pemissions launching on
* enable multi-account checking by specifying STS_ROLE cross-account role name option
* in addition to the image owner account id which will be checked by default