### PR TITLE
readonly the identifiers, not their values

### DIFF
--- a/bin/make-lambda-build
+++ b/bin/make-lambda-build
@@ -11,8 +11,8 @@ cleanup() {
 trap "cleanup" EXIT INT
 build_dir=$(mktemp -d)
 lambda_tools="rds-snapshot-cleaner trusted-advisor-refresh iam-keys-check aws-health-notifier ami-cleaner packer-janitor"
-readonly "$build_dir"
-readonly "$lambda_tools"
+readonly build_dir
+readonly lambda_tools
 mkdir -p "$build_dir"
 
 for cmd in $lambda_tools


### PR DESCRIPTION
Before this change, doing

```console
$ make S3_BUCKET=dol-ui-claimant-intake-dev-lambda-builds-us-east-1 lambda_release
```
would cause an error like this
```
in/make-lambda-build: line 14: readonly: `/var/folders/dv/4lwc_5g10m7988rszs5thkk00000gn/T/tmp.Ml1oKjWm': not a valid identifier
```
because the variable was being substituted before the value was passed to `readonly`.